### PR TITLE
chore: hide language selection

### DIFF
--- a/app/_components/header/DesktopHeader.tsx
+++ b/app/_components/header/DesktopHeader.tsx
@@ -8,7 +8,7 @@ import {AnimateChangeInHeight} from '@/app/_components/AnimatedHeight';
 import {Button} from '@/app/_components/Button';
 import {LocalizedLink} from '@/app/_components/LocalizedLink';
 import {Notification} from '@/app/_components/Notification';
-import {IconPlanet} from '@/app/_icons/IconPlanet';
+// import {IconPlanet} from '@/app/_icons/IconPlanet';
 import {ShapeshiftLogo} from '@/app/_icons/ShapeshiftLogo';
 import {cl} from '@/app/_utils/cl';
 import {dAppUrl, headerTabs} from '@/app/_utils/constants';
@@ -103,13 +103,13 @@ export function DesktopHeader({className, switchLanguageAction, currentLanguage}
 						</nav>
 
 						<div className={'flex gap-2'}>
-							<button
+							{/* <button
 								onMouseEnter={() => setCurrentTab('language')}
 								className={
 									'group flex aspect-square h-14 items-center justify-center rounded-[20px] border border-white/5'
 								}>
 								<IconPlanet className={'opacity-50 transition-opacity group-hover:opacity-100'} />
-							</button>
+							</button> */}
 							<Button
 								variant={'blue'}
 								title={'Launch App'}

--- a/app/_components/header/MobileHeader.tsx
+++ b/app/_components/header/MobileHeader.tsx
@@ -10,7 +10,7 @@ import {AnimatedPlusMinusIcon} from '@/app/_components/QuestionSection';
 import {IconCheck} from '@/app/_icons/IconCheck';
 import {IconClose} from '@/app/_icons/IconClose';
 import {IconMenu} from '@/app/_icons/IconMenu';
-import {IconPlanet} from '@/app/_icons/IconPlanet';
+// import {IconPlanet} from '@/app/_icons/IconPlanet';
 import {IconShapeshift} from '@/app/_icons/IconShapeshift';
 import {appDao, appProducts, appResources, headerTabs} from '@/app/_utils/constants';
 import {SUPPORTED_LANGUAGES} from '@/app/_utils/i18nconfig';
@@ -169,14 +169,14 @@ export function MobileHeader({
 								</div>
 							</div>
 							<div>
-								<button
+								{/* <button
 									onClick={() => setExpandedSection(expandedSection === 'language' ? '' : 'language')}
 									className={
 										'mb-10 mt-6 flex w-full items-center justify-between gap-2 rounded-2xl border border-white/50 bg-white/10 p-4'
 									}>
 									<span>{SUPPORTED_LANGUAGES.find(l => l.code === currentLanguage)?.name}</span>
 									<IconPlanet className={'text-white/50'} />
-								</button>
+								</button> */}
 								<AnimatePresence>
 									{expandedSection === 'language' && (
 										<motion.div


### PR DESCRIPTION
We don't currently support any language other than English.
We shouldn't show a language selection that doesn't work...

Production:

<img width="1039" alt="Screenshot 2025-06-23 at 11 15 39 am" src="https://github.com/user-attachments/assets/d1ff4289-29eb-4ff7-a2b4-d90738500c22" />

This branch:

<img width="1025" alt="Screenshot 2025-06-23 at 11 16 10 am" src="https://github.com/user-attachments/assets/d359a4dd-f72e-4845-8904-8bd3ef56a248" />

Revert me when translations are ready/working.