### PR TITLE
fix: use NEXT_PUBLIC_ var naming

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,5 +1,5 @@
-STRAPI_URL=https://strapi.shapeshift.com
-STRAPI_API_TOKEN=obtain-from-engineering
-WEGLOT_API_KEY=obtain-from-engineering
-ONRAMPER_URL=https://buy.onramper.com/?apiKey=pk_prod_01HWMA66BYRB2271G08XDZVVCX&defaultCrypto=btc&wallets=btc%3A&onlyCryptos=btc&supportSell=false&isAddressEditable=false&language=en&defaultFiat=USD&themeName=dark&redirectURL=https%3A%2F%2Fapp.shapeshift.com%2F%23%2Fbuy-crypto&signature=cf9f78149db21574bbfe02dc72a1ab15ae15a0bd25d7b932ef0b453d8a922f30
-CHATWOOT_API_KEY=obtain-from-engineering
+NEXT_PUBLIC_STRAPI_URL=https://strapi.shapeshift.com
+NEXT_PUBLIC_STRAPI_API_TOKEN=obtain-from-engineering
+NEXT_PUBLIC_WEGLOT_API_KEY=obtain-from-engineering
+NEXT_PUBLIC_ONRAMPER_URL=https://buy.onramper.com/?apiKey=pk_prod_01HWMA66BYRB2271G08XDZVVCX&defaultCrypto=btc&wallets=btc%3A&onlyCryptos=btc&supportSell=false&isAddressEditable=false&language=en&defaultFiat=USD&themeName=dark&redirectURL=https%3A%2F%2Fapp.shapeshift.com%2F%23%2Fbuy-crypto&signature=cf9f78149db21574bbfe02dc72a1ab15ae15a0bd25d7b932ef0b453d8a922f30
+NEXT_PUBLIC_CHATWOOT_API_KEY=obtain-from-engineering

--- a/app/[lang]/(core-products)/_components/ProductHero.tsx
+++ b/app/[lang]/(core-products)/_components/ProductHero.tsx
@@ -63,7 +63,7 @@ export function ProductHero({
 
 				<div className={'mt-20 aspect-[1400/400] overflow-hidden rounded-2xl'}>
 					<Image
-						src={`${process.env.STRAPI_URL}${featuredImg.url}`}
+						src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${featuredImg.url}`}
 						className={'aspect-[1400/400] w-full'}
 						alt={title || 'Product feature image'}
 						quality={100}

--- a/app/[lang]/(core-products)/_components/fetchUtils.ts
+++ b/app/[lang]/(core-products)/_components/fetchUtils.ts
@@ -12,9 +12,9 @@ export async function fetchWithErrorHandling<T>(
 	error: string
 ): Promise<T | null> {
 	try {
-		const response = await fetch(`${process.env.STRAPI_URL}/api/${endpoint}?${queryParams}`, {
+		const response = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/${endpoint}?${queryParams}`, {
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			},
 			next: {
 				revalidate: 3600 // Cache for 1 hour

--- a/app/[lang]/(core-products)/defi-wallet/page.tsx
+++ b/app/[lang]/(core-products)/defi-wallet/page.tsx
@@ -48,7 +48,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			type: 'website',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}${page.featuredImg.url}`,
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`,
 					width: 1200,
 					height: 630,
 					alt: page.title
@@ -59,7 +59,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			card: 'summary_large_image',
 			title: page.title,
 			description: page.description,
-			images: [`${process.env.STRAPI_URL}${page.featuredImg.url}`]
+			images: [`${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`]
 		}
 	};
 }
@@ -88,7 +88,7 @@ export default async function DeFiWalletPage(): Promise<ReactNode> {
 	const productSchema = generateProductSchema({
 		title: page.title,
 		description: page.description,
-		featuredImage: `${process.env.STRAPI_URL}${page.featuredImg.url}`,
+		featuredImage: `${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`,
 		pageURL,
 		features
 	});

--- a/app/[lang]/(core-products)/earn/page.tsx
+++ b/app/[lang]/(core-products)/earn/page.tsx
@@ -46,7 +46,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			type: 'website',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}${page.featuredImg.url}`,
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`,
 					width: 1200,
 					height: 630,
 					alt: page.title
@@ -57,7 +57,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			card: 'summary_large_image',
 			title: page.title,
 			description: page.description,
-			images: [`${process.env.STRAPI_URL}${page.featuredImg.url}`]
+			images: [`${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`]
 		}
 	};
 }
@@ -86,7 +86,7 @@ export default async function EarnPage(): Promise<ReactNode> {
 	const productSchema = generateProductSchema({
 		title: page.title,
 		description: page.description,
-		featuredImage: `${process.env.STRAPI_URL}${page.featuredImg.url}`,
+		featuredImage: `${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`,
 		pageURL,
 		features
 	});

--- a/app/[lang]/(core-products)/mobile-app/page.tsx
+++ b/app/[lang]/(core-products)/mobile-app/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			type: 'website',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}${page.featuredImg.url}`,
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`,
 					width: 1200,
 					height: 630,
 					alt: page.title
@@ -58,7 +58,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			card: 'summary_large_image',
 			title: page.title,
 			description: page.description,
-			images: [`${process.env.STRAPI_URL}${page.featuredImg.url}`]
+			images: [`${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`]
 		}
 	};
 }
@@ -87,7 +87,7 @@ export default async function MobileAppPage(): Promise<ReactNode> {
 	const productSchema = generateProductSchema({
 		title: page.title,
 		description: page.description,
-		featuredImage: `${process.env.STRAPI_URL}${page.featuredImg.url}`,
+		featuredImage: `${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`,
 		pageURL,
 		features
 	});

--- a/app/[lang]/(core-products)/trade/page.tsx
+++ b/app/[lang]/(core-products)/trade/page.tsx
@@ -52,7 +52,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			type: 'website',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}${page.featuredImg.url}`,
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`,
 					width: 1200,
 					height: 630,
 					alt: page.title
@@ -63,7 +63,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			card: 'summary_large_image',
 			title: page.title,
 			description: page.description,
-			images: [`${process.env.STRAPI_URL}${page.featuredImg.url}`]
+			images: [`${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`]
 		}
 	};
 }
@@ -92,7 +92,7 @@ export default async function TradePage(): Promise<ReactNode> {
 	const productSchema = generateProductSchema({
 		title: page.title,
 		description: page.description,
-		featuredImage: `${process.env.STRAPI_URL}${page.featuredImg.url}`,
+		featuredImage: `${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`,
 		pageURL,
 		features
 	});
@@ -115,7 +115,7 @@ export default async function TradePage(): Promise<ReactNode> {
 				title={page.title}
 				description={page.description}
 				buttonCta={page.buttonCta}
-				imageUrl={`${process.env.STRAPI_URL}${page.featuredImg.url}`}
+				imageUrl={`${process.env.NEXT_PUBLIC_STRAPI_URL}${page.featuredImg.url}`}
 			/>
 
 			{/* Feature cards section */}

--- a/app/[lang]/(resources)/_components/DiscoverFeature.tsx
+++ b/app/[lang]/(resources)/_components/DiscoverFeature.tsx
@@ -90,7 +90,7 @@ export function DiscoverFeature({
 									src={
 										feature.image.url.startsWith('http')
 											? feature.image.url
-											: `${process.env.STRAPI_URL}${feature.image.url}`
+											: `${process.env.NEXT_PUBLIC_STRAPI_URL}${feature.image.url}`
 									}
 									alt={feature.image.alt || feature.title}
 									width={feature.image.width || 64}

--- a/app/[lang]/(resources)/_components/ResourceCard.tsx
+++ b/app/[lang]/(resources)/_components/ResourceCard.tsx
@@ -85,7 +85,7 @@ export function ResourceCard({
 						transition={{duration: 0.5}}
 						className={'relative z-10 size-full object-contain'}>
 						<Image
-							src={imageUrl.startsWith('http') ? imageUrl : `${process.env.STRAPI_URL}${imageUrl}`}
+							src={imageUrl.startsWith('http') ? imageUrl : `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`}
 							alt={altText || title}
 							width={imageWidth || 100}
 							height={imageHeight || 100}

--- a/app/[lang]/(resources)/_utils/fetchUtils.ts
+++ b/app/[lang]/(resources)/_utils/fetchUtils.ts
@@ -26,7 +26,7 @@ import type {
 // Common headers and cache configuration
 const apiConfig = {
 	headers: {
-		Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+		Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 	},
 	next: {
 		revalidate: 3600 // Cache for 1 hour
@@ -40,7 +40,7 @@ const apiConfig = {
  ************************************************************************************************/
 export async function fetchAllProtocols(): Promise<TSupportedProtocolData[] | null> {
 	try {
-		const response = await fetch(`${process.env.STRAPI_URL}/api/supported-protocols?populate=*`, apiConfig);
+		const response = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-protocols?populate=*`, apiConfig);
 
 		if (!response.ok) {
 			console.error(`Failed to fetch protocols: ${response.status}`);
@@ -62,7 +62,7 @@ export async function fetchAllProtocols(): Promise<TSupportedProtocolData[] | nu
  ************************************************************************************************/
 export async function fetchAllChains(): Promise<TSupportedChainData[] | null> {
 	try {
-		const response = await fetch(`${process.env.STRAPI_URL}/api/supported-chains?populate=*`, apiConfig);
+		const response = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-chains?populate=*`, apiConfig);
 
 		if (!response.ok) {
 			console.error(`Failed to fetch chains: ${response.status}`);
@@ -84,7 +84,7 @@ export async function fetchAllChains(): Promise<TSupportedChainData[] | null> {
  ************************************************************************************************/
 export async function fetchAllWallets(): Promise<TSupportedWalletData[] | null> {
 	try {
-		const response = await fetch(`${process.env.STRAPI_URL}/api/supported-wallets?populate=*`, apiConfig);
+		const response = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-wallets?populate=*`, apiConfig);
 
 		if (!response.ok) {
 			console.error(`Failed to fetch wallets: ${response.status}`);
@@ -108,7 +108,7 @@ export async function fetchAllWallets(): Promise<TSupportedWalletData[] | null> 
 export async function fetchDiscoverBySlug(slug: string): Promise<TDiscoverData | null> {
 	try {
 		const response = await fetch(
-			`${process.env.STRAPI_URL}/api/discovers?filters[slug][$eq]=${slug}&populate[0]=features&fields[1]=title&fields[2]=description&populate[3]=featuredImg&populate[4]=features.image&fields[5]=tag&populate[6]=features.buttonCta`,
+			`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/discovers?filters[slug][$eq]=${slug}&populate[0]=features&fields[1]=title&fields[2]=description&populate[3]=featuredImg&populate[4]=features.image&fields[5]=tag&populate[6]=features.buttonCta`,
 			apiConfig
 		);
 
@@ -136,7 +136,7 @@ export async function fetchDiscoverBySlug(slug: string): Promise<TDiscoverData |
 export async function fetchFaqData(): Promise<TFaqData | null> {
 	try {
 		const response = await fetch(
-			`${process.env.STRAPI_URL}/api/faq?populate[faqSection][populate][faqSectionItem][populate]=*`,
+			`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/faq?populate[faqSection][populate][faqSectionItem][populate]=*`,
 			apiConfig
 		);
 

--- a/app/[lang]/(resources)/blog/(withNavigation)/categories/[category]/page.tsx
+++ b/app/[lang]/(resources)/blog/(withNavigation)/categories/[category]/page.tsx
@@ -7,10 +7,10 @@ export default async function BlogCategoriesPage(props: {
 }): Promise<React.ReactNode> {
 	const {category} = await props.params;
 	const data = await fetch(
-		`${process.env.STRAPI_URL}/api/posts?filters[type][$contains]=${category}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc&pagination[pageSize]=1`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/posts?filters[type][$contains]=${category}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc&pagination[pageSize]=1`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	);

--- a/app/[lang]/(resources)/blog/(withNavigation)/tags/[tag]/page.tsx
+++ b/app/[lang]/(resources)/blog/(withNavigation)/tags/[tag]/page.tsx
@@ -5,10 +5,10 @@ import {ListOfPosts} from '@/app/[lang]/(resources)/blog/(withNavigation)/tags/[
 export default async function BlogTagsPage(props: {params: Promise<{tag: string}>}): Promise<React.ReactNode> {
 	const {tag} = await props.params;
 	const data = await fetch(
-		`${process.env.STRAPI_URL}/api/posts?filters[tags][$contains]=${tag}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/posts?filters[tags][$contains]=${tag}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	);

--- a/app/[lang]/(resources)/blog/[slug]/layout.tsx
+++ b/app/[lang]/(resources)/blog/[slug]/layout.tsx
@@ -10,10 +10,10 @@ import type {Metadata} from 'next';
 export async function generateMetadata({params}: {params: Promise<{slug: string}>}): Promise<Metadata> {
 	const {slug} = await params;
 	const data = await fetch(
-		`${process.env.STRAPI_URL}/api/posts?filters[slug][$eq]=${slug}&fields[0]=summary&fields[2]=tags&fields[3]=title&fields[4]=publishedAt&populate[0]=featuredImg`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/posts?filters[slug][$eq]=${slug}&fields[0]=summary&fields[2]=tags&fields[3]=title&fields[4]=publishedAt&populate[0]=featuredImg`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	).then(async res => res.json());
@@ -47,12 +47,12 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	if (imageUrl) {
 		metadata.openGraph!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 		metadata.twitter!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 	}

--- a/app/[lang]/(resources)/chains/[slug]/page.tsx
+++ b/app/[lang]/(resources)/chains/[slug]/page.tsx
@@ -20,10 +20,10 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	}
 
 	const response = await fetch(
-		`${process.env.STRAPI_URL}/api/supported-chains?filters[slug][$eq]=${slug}&populate=*`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-chains?filters[slug][$eq]=${slug}&populate=*`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	);
@@ -53,12 +53,12 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	if (imageUrl) {
 		metadata.openGraph!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 		metadata.twitter!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 	}
@@ -90,7 +90,7 @@ export default async function ChainPage({params}: {params: Promise<{slug: string
 
 				<div className={'mb-20 mt-16 lg:mb-60'}>
 					<ChainHero
-						url={`${process.env.STRAPI_URL}${chain?.featuredImg?.url}`}
+						url={`${process.env.NEXT_PUBLIC_STRAPI_URL}${chain?.featuredImg?.url}`}
 						name={chain?.name}
 						width={chain?.featuredImg?.width}
 						height={chain?.featuredImg?.height}

--- a/app/[lang]/(resources)/chains/layout.tsx
+++ b/app/[lang]/(resources)/chains/layout.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			type: 'website',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}/og.png`
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}/og.png`
 				}
 			]
 		},
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			description: 'Discover all the chains ShapeShift supports. Buy, sell, and swap crypto with ease.',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}/og.png`
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}/og.png`
 				}
 			]
 		}

--- a/app/[lang]/(resources)/discover/[slug]/page.tsx
+++ b/app/[lang]/(resources)/discover/[slug]/page.tsx
@@ -67,12 +67,12 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	if (imageUrl) {
 		metadata.openGraph!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 		metadata.twitter!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 	}
@@ -100,7 +100,7 @@ export default async function DiscoverDetailPage({params}: {params: Promise<{slu
 		description: feature.description,
 		image: feature.image
 			? {
-					url: `${process.env.STRAPI_URL}${feature.image.url}`,
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${feature.image.url}`,
 					width: feature.image.width,
 					height: feature.image.height,
 					alt: feature.title
@@ -126,7 +126,7 @@ export default async function DiscoverDetailPage({params}: {params: Promise<{slu
 				<ResourceHero
 					imageSrc={'/wallets/hero.jpg'}
 					imageAlt={`${discover.title} banner image`}
-					logoSrc={`${process.env.STRAPI_URL}${discover.featuredImg.url}`}
+					logoSrc={`${process.env.NEXT_PUBLIC_STRAPI_URL}${discover.featuredImg.url}`}
 					logoAlt={discover.title}
 					logoWidth={discover.featuredImg.width}
 					logoHeight={discover.featuredImg.height}

--- a/app/[lang]/(resources)/discover/layout.tsx
+++ b/app/[lang]/(resources)/discover/layout.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			type: 'website',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}/og.png`
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}/og.png`
 				}
 			]
 		},
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			description: 'Discover the world of Web3 with ShapeShift.',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}/og.png`
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}/og.png`
 				}
 			]
 		}

--- a/app/[lang]/(resources)/newsroom/(withNavigation)/categories/[category]/page.tsx
+++ b/app/[lang]/(resources)/newsroom/(withNavigation)/categories/[category]/page.tsx
@@ -7,10 +7,10 @@ export default async function BlogCategoriesPage(props: {
 }): Promise<React.ReactNode> {
 	const {category} = await props.params;
 	const data = await fetch(
-		`${process.env.STRAPI_URL}/api/newsrooms?filters[category][$contains]=${category}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc&pagination[pageSize]=1`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/newsrooms?filters[category][$contains]=${category}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc&pagination[pageSize]=1`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	);

--- a/app/[lang]/(resources)/newsroom/(withNavigation)/tags/[tag]/page.tsx
+++ b/app/[lang]/(resources)/newsroom/(withNavigation)/tags/[tag]/page.tsx
@@ -5,10 +5,10 @@ import {ListOfPosts} from '@/app/[lang]/(resources)/newsroom/(withNavigation)/ta
 export default async function NewsroomTagsPage(props: {params: Promise<{tag: string}>}): Promise<React.ReactNode> {
 	const {tag} = await props.params;
 	const data = await fetch(
-		`${process.env.STRAPI_URL}/api/newsrooms?filters[tags][$contains]=${tag}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/newsrooms?filters[tags][$contains]=${tag}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	);

--- a/app/[lang]/(resources)/newsroom/[slug]/layout.tsx
+++ b/app/[lang]/(resources)/newsroom/[slug]/layout.tsx
@@ -10,10 +10,10 @@ import type {Metadata} from 'next';
 export async function generateMetadata({params}: {params: Promise<{slug: string}>}): Promise<Metadata> {
 	const {slug} = await params;
 	const data = await fetch(
-		`${process.env.STRAPI_URL}/api/newsrooms?filters[slug][$eq]=${slug}&fields[0]=postSummary&fields[1]=tags&fields[2]=title&fields[3]=publishedAt&populate[0]=featuredImg`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/newsrooms?filters[slug][$eq]=${slug}&fields[0]=postSummary&fields[1]=tags&fields[2]=title&fields[3]=publishedAt&populate[0]=featuredImg`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	).then(async res => res.json());
@@ -47,12 +47,12 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	if (imageUrl) {
 		metadata.openGraph!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 		metadata.twitter!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 	}

--- a/app/[lang]/(resources)/protocols/[slug]/page.tsx
+++ b/app/[lang]/(resources)/protocols/[slug]/page.tsx
@@ -19,10 +19,10 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	}
 
 	const response = await fetch(
-		`${process.env.STRAPI_URL}/api/supported-protocols?filters[slug][$eq]=${slug}&populate=*`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-protocols?filters[slug][$eq]=${slug}&populate=*`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	);
@@ -53,12 +53,12 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	if (imageUrl) {
 		metadata.openGraph!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 		metadata.twitter!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 	}
@@ -90,7 +90,7 @@ export default async function ProtocolPage({params}: {params: Promise<{slug: str
 					name={protocol?.name}
 					description={protocol?.description}
 					items={['Self-custodial', 'Private', 'Multichain trading']}
-					url={`${process.env.STRAPI_URL}${protocol?.featuredImg?.url}`}
+					url={`${process.env.NEXT_PUBLIC_STRAPI_URL}${protocol?.featuredImg?.url}`}
 					width={protocol?.featuredImg?.width}
 					height={protocol?.featuredImg?.height}
 				/>

--- a/app/[lang]/(resources)/protocols/layout.tsx
+++ b/app/[lang]/(resources)/protocols/layout.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			type: 'website',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}/og.png`
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}/og.png`
 				}
 			]
 		},
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			description: 'Discover all the protocols ShapeShift supports. Buy, sell, and swap crypto with ease.',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}/og.png`
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}/og.png`
 				}
 			]
 		}

--- a/app/[lang]/(resources)/wallets/[slug]/page.tsx
+++ b/app/[lang]/(resources)/wallets/[slug]/page.tsx
@@ -18,10 +18,10 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	}
 
 	const response = await fetch(
-		`${process.env.STRAPI_URL}/api/supported-wallets?filters[slug][$eq]=${slug}&populate=*`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-wallets?filters[slug][$eq]=${slug}&populate=*`,
 		{
 			headers: {
-				Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+				Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 			}
 		}
 	);
@@ -51,12 +51,12 @@ export async function generateMetadata({params}: {params: Promise<{slug: string}
 	if (imageUrl) {
 		metadata.openGraph!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 		metadata.twitter!.images = [
 			{
-				url: `${process.env.STRAPI_URL}${imageUrl}`
+				url: `${process.env.NEXT_PUBLIC_STRAPI_URL}${imageUrl}`
 			}
 		];
 	}
@@ -77,7 +77,7 @@ export default async function WalletPage({params}: {params: Promise<{slug: strin
 			<div className={'container mt-[60px] flex flex-col justify-center'}>
 				<div className={'mb-12'}>
 					<SupportedWalletHero
-						url={`${process.env.STRAPI_URL}${wallet?.featuredImg?.url}`}
+						url={`${process.env.NEXT_PUBLIC_STRAPI_URL}${wallet?.featuredImg?.url}`}
 						name={wallet?.name}
 						width={wallet?.featuredImg?.width}
 						height={wallet?.featuredImg?.height}

--- a/app/[lang]/(resources)/wallets/layout.tsx
+++ b/app/[lang]/(resources)/wallets/layout.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			type: 'website',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}/og.png`
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}/og.png`
 				}
 			]
 		},
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			description: 'Discover all the wallets ShapeShift supports. Buy, sell, and swap crypto with ease.',
 			images: [
 				{
-					url: `${process.env.STRAPI_URL}/og.png`
+					url: `${process.env.NEXT_PUBLIC_STRAPI_URL}/og.png`
 				}
 			]
 		}

--- a/app/[lang]/_components/BlogPost.tsx
+++ b/app/[lang]/_components/BlogPost.tsx
@@ -67,7 +67,7 @@ function FeaturedPost({post, className}: {post: TBlogPost; className?: string}):
 				className={'no-translate col-span-1 size-full max-h-[316px] max-w-[632px] overflow-hidden rounded-2xl'}>
 				{post?.featuredImg?.url ? (
 					<Image
-						src={`${process.env.STRAPI_URL}${post?.featuredImg.url}`}
+						src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${post?.featuredImg.url}`}
 						alt={post.slug}
 						width={post?.featuredImg.width ?? 0}
 						height={post?.featuredImg.height ?? 0}
@@ -120,7 +120,7 @@ function PostCard({post, className}: {post: TBlogPost; className?: string}): Rea
 			<div className={'h-[204px] max-w-[408px] overflow-hidden rounded-2xl'}>
 				{post?.featuredImg?.url ? (
 					<Image
-						src={`${process.env.STRAPI_URL}${post?.featuredImg?.url}`}
+						src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${post?.featuredImg?.url}`}
 						alt={post.slug}
 						width={post?.featuredImg?.width ?? 0}
 						height={post?.featuredImg?.height ?? 0}

--- a/app/[lang]/_components/ChatwootWidget.tsx
+++ b/app/[lang]/_components/ChatwootWidget.tsx
@@ -19,12 +19,12 @@ export function ChatwootWidget(): JSX.Element {
 		// Initialize Chatwoot when the script loads
 		const initChatwoot = (): void => {
 			if (window.chatwootSDK) {
-				if (!process.env.CHATWOOT_API_KEY) {
-					console.error('CHATWOOT_API_KEY is not set');
+				if (!process.env.NEXT_PUBLIC_CHATWOOT_API_KEY) {
+					console.error('NEXT_PUBLIC_CHATWOOT_API_KEY is not set');
 					return;
 				}
 				window.chatwootSDK.run({
-					websiteToken: process.env.CHATWOOT_API_KEY || '',
+					websiteToken: process.env.NEXT_PUBLIC_CHATWOOT_API_KEY || '',
 					baseUrl: 'https://app.chatwoot.com/'
 				});
 			}
@@ -42,12 +42,12 @@ export function ChatwootWidget(): JSX.Element {
 			strategy={'afterInteractive'}
 			onLoad={() => {
 				if (window.chatwootSDK) {
-					if (!process.env.CHATWOOT_API_KEY) {
-						console.error('CHATWOOT_API_KEY is not set');
+					if (!process.env.NEXT_PUBLIC_CHATWOOT_API_KEY) {
+						console.error('NEXT_PUBLIC_CHATWOOT_API_KEY is not set');
 						return;
 					}
 					window.chatwootSDK.run({
-						websiteToken: process.env.CHATWOOT_API_KEY || '',
+						websiteToken: process.env.NEXT_PUBLIC_CHATWOOT_API_KEY || '',
 						baseUrl: 'https://app.chatwoot.com/'
 					});
 				}

--- a/app/[lang]/_components/ElementCard.tsx
+++ b/app/[lang]/_components/ElementCard.tsx
@@ -54,7 +54,7 @@ export function ElementCard(props: TElementCardProps): ReactNode {
 						transition={{duration: 0.5}}
 						className={'relative z-10 size-full object-contain'}>
 						<Image
-							src={`${process.env.STRAPI_URL}${featuredImg?.url}`}
+							src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${featuredImg?.url}`}
 							alt={slug}
 							width={featuredImg?.width ?? 0}
 							height={featuredImg?.height ?? 0}

--- a/app/[lang]/_components/NewsPost.tsx
+++ b/app/[lang]/_components/NewsPost.tsx
@@ -54,7 +54,7 @@ export function NewsPost({post, className}: {post: TNewsroomPost; className?: st
 			<div className={'h-[204px] max-w-[408px] overflow-hidden rounded-2xl'}>
 				{post?.featuredImg?.url ? (
 					<Image
-						src={`${process.env.STRAPI_URL}${post?.featuredImg?.url}`}
+						src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${post?.featuredImg?.url}`}
 						alt={post.slug}
 						width={post?.featuredImg?.width ?? 0}
 						height={post?.featuredImg?.height ?? 0}

--- a/app/[lang]/_components/Notification.tsx
+++ b/app/[lang]/_components/Notification.tsx
@@ -26,9 +26,9 @@ export function Notification(): ReactNode {
 	useEffect(() => {
 		const fetchData = async (): Promise<void> => {
 			try {
-				const res = await fetch(`${process.env.STRAPI_URL}/api/notification?populate=*`, {
+				const res = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/notification?populate=*`, {
 					headers: {
-						Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+						Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 					}
 				});
 				const data = await res.json();

--- a/app/[lang]/_components/Popup.tsx
+++ b/app/[lang]/_components/Popup.tsx
@@ -54,7 +54,7 @@ export function Popup({
 						style={{
 							...(notification?.bgImage?.url
 								? {
-										background: `url(${`${process.env.STRAPI_URL}${notification.bgImage.url}`}) no-repeat center center`,
+										background: `url(${`${process.env.NEXT_PUBLIC_STRAPI_URL}${notification.bgImage.url}`}) no-repeat center center`,
 										backgroundSize: 'cover'
 									}
 								: null)

--- a/app/[lang]/_components/strapi/cards-row/Card.tsx
+++ b/app/[lang]/_components/strapi/cards-row/Card.tsx
@@ -32,7 +32,7 @@ export function Card({data, smaller}: {data: TCard; smaller?: boolean}): ReactNo
 						backgroundPosition: 'center'
 					}}>
 					<Image
-						src={`${process.env.STRAPI_URL}${data?.image.url}`}
+						src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${data?.image.url}`}
 						alt={data?.title}
 						width={461}
 						height={219}
@@ -62,7 +62,7 @@ export function Card({data, smaller}: {data: TCard; smaller?: boolean}): ReactNo
 					backgroundPosition: 'center'
 				}}>
 				<Image
-					src={`${process.env.STRAPI_URL}${data?.image.url}`}
+					src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${data?.image.url}`}
 					alt={data?.title}
 					width={461}
 					height={219}

--- a/app/[lang]/_components/strapi/products/BuyCryptoCard.tsx
+++ b/app/[lang]/_components/strapi/products/BuyCryptoCard.tsx
@@ -25,7 +25,7 @@ export function BuyCryptoCard(): ReactNode {
 				</div>
 				<div className={'my-10 size-min overflow-hidden rounded-2xl'}>
 					<iframe
-						src={process.env.ONRAMPER_URL}
+						src={process.env.NEXT_PUBLIC_ONRAMPER_URL}
 						title={PRODUCTS_DICT.buyCrypto.widgetTitle}
 						height={'630px'}
 						width={'420px'}

--- a/app/[lang]/_components/strapi/products/CarouselCard.tsx
+++ b/app/[lang]/_components/strapi/products/CarouselCard.tsx
@@ -34,7 +34,7 @@ export function CarouselCard({title, description, items, image}: TCarouselCardPr
 									className={'mx-6'}>
 									<div className={'relative flex max-h-10 w-max items-center justify-start'}>
 										<Image
-											src={`${process.env.STRAPI_URL}${image?.url ?? ''}`}
+											src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${image?.url ?? ''}`}
 											alt={image?.url || ''}
 											width={696}
 											height={168}
@@ -47,7 +47,7 @@ export function CarouselCard({title, description, items, image}: TCarouselCardPr
 					) : (
 						<div className={'mt-auto overflow-hidden'}>
 							<Image
-								src={`${process.env.STRAPI_URL}${image?.url ?? ''}`}
+								src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${image?.url ?? ''}`}
 								alt={title}
 								width={696}
 								height={168}

--- a/app/[lang]/_components/strapi/products/ChainBubblesCard.tsx
+++ b/app/[lang]/_components/strapi/products/ChainBubblesCard.tsx
@@ -57,7 +57,7 @@ export function ChainBubblesCard({title, description, items, randomDelays}: TCha
 										'absolute left-1/2 top-1/2 size-[62px] -translate-x-1/2 -translate-y-1/2'
 									}>
 									<Image
-										src={`${hasChainItemsFromStrapi ? process.env.STRAPI_URL : ''}${item.image?.url ?? ''}`}
+										src={`${hasChainItemsFromStrapi ? process.env.NEXT_PUBLIC_STRAPI_URL : ''}${item.image?.url ?? ''}`}
 										alt={item.image?.url || ''}
 										width={62}
 										height={62}
@@ -96,7 +96,7 @@ export function ChainBubblesCard({title, description, items, randomDelays}: TCha
 										'absolute left-1/2 top-1/2 size-[32px] -translate-x-1/2 -translate-y-1/2'
 									}>
 									<Image
-										src={`${hasChainItemsFromStrapi ? process.env.STRAPI_URL : ''}${item.image?.url ?? ''}`}
+										src={`${hasChainItemsFromStrapi ? process.env.NEXT_PUBLIC_STRAPI_URL : ''}${item.image?.url ?? ''}`}
 										alt={item.image?.url || ''}
 										width={62}
 										height={62}

--- a/app/[lang]/_components/strapi/products/Grid.tsx
+++ b/app/[lang]/_components/strapi/products/Grid.tsx
@@ -62,7 +62,7 @@ function Card({data, className}: {data: TCard; className: string}): ReactNode {
 				<div className={'text-gray-500'}>{data?.description}</div>
 			</div>
 			<Image
-				src={`${process.env.STRAPI_URL}${data?.image.url}`}
+				src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${data?.image.url}`}
 				alt={data?.title}
 				width={data?.image.width}
 				height={data?.image.height}

--- a/app/[lang]/_components/strapi/products/GridDisplaced.tsx
+++ b/app/[lang]/_components/strapi/products/GridDisplaced.tsx
@@ -51,7 +51,7 @@ export default function GridDisplaced({data}: {data: TGridDisplacedSection}): Re
 							</div>
 							<div className={'mt-auto overflow-hidden'}>
 								<Image
-									src={`${process.env.STRAPI_URL}${data?.cards[2]?.image?.url}`}
+									src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${data?.cards[2]?.image?.url}`}
 									alt={data?.cards[2]?.title}
 									width={696}
 									height={168}

--- a/app/[lang]/_components/strapi/products/GridLadder.tsx
+++ b/app/[lang]/_components/strapi/products/GridLadder.tsx
@@ -33,7 +33,7 @@ export default function GridLadder({data}: {data: TGridLadderSection}): ReactNod
 							<LadderItem data={step} />
 							<div className={'h-[400px] w-[640px] overflow-hidden rounded-2xl bg-secondHoverBg'}>
 								<Image
-									src={`${process.env.STRAPI_URL}${step.image?.url}`}
+									src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${step.image?.url}`}
 									alt={step.id.toString()}
 									width={step.image?.width}
 									height={step.image?.height}

--- a/app/[lang]/_components/strapi/templates/ChainFeatures.tsx
+++ b/app/[lang]/_components/strapi/templates/ChainFeatures.tsx
@@ -200,7 +200,7 @@ function CustodialFeature({chainName, foxImg}: {chainName: string; foxImg: TStra
 			</div>
 			<div className={'mx-auto mt-auto flex aspect-video w-2/3 items-end justify-end'}>
 				<Image
-					src={`${process.env.STRAPI_URL}${foxImg.url}`}
+					src={`${process.env.NEXT_PUBLIC_STRAPI_URL}${foxImg.url}`}
 					alt={''}
 					className={'h-auto w-full object-contain object-bottom'}
 					width={foxImg.width}

--- a/app/[lang]/_hooks/useFetchNewsroom.tsx
+++ b/app/[lang]/_hooks/useFetchNewsroom.tsx
@@ -76,10 +76,10 @@ export function useFetchNewsroom({
 			try {
 				// Fetch posts with featured image population
 				const res = await fetch(
-					`${process.env.STRAPI_URL}/api/newsrooms?populate[0]=featuredImg&fields[0]=slug&fields[1]=postSummary&fields[2]=title&fields[3]=category&fields[4]=tags&fields[5]=publishedAt&fields[7]=publishedOn&fields[14]=author&fields[8]=externalURL&sort[0]=publishedOn:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[6]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}${category ? `&filters[category][$contains]=${category.replace(/ /g, '_')}` : ''}${tag ? `&filters[tags][$contains]=${tag.replace(/ /g, '_')}` : ''}`,
+					`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/newsrooms?populate[0]=featuredImg&fields[0]=slug&fields[1]=postSummary&fields[2]=title&fields[3]=category&fields[4]=tags&fields[5]=publishedAt&fields[7]=publishedOn&fields[14]=author&fields[8]=externalURL&sort[0]=publishedOn:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[6]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}${category ? `&filters[category][$contains]=${category.replace(/ /g, '_')}` : ''}${tag ? `&filters[tags][$contains]=${tag.replace(/ /g, '_')}` : ''}`,
 					{
 						headers: {
-							Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+							Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 						}
 					}
 				);

--- a/app/[lang]/_hooks/useFetchPosts.tsx
+++ b/app/[lang]/_hooks/useFetchPosts.tsx
@@ -96,10 +96,10 @@ export function useFetchPosts({
 			try {
 				// Fetch posts with featured image population
 				const res = await fetch(
-					`${process.env.STRAPI_URL}/api/posts?populate[0]=featuredImg&fields[0]=slug&fields[1]=summary&fields[2]=title&fields[3]=type&fields[4]=tags&fields[5]=publishedAt&fields[6]=isFeatured&sort[0]=isFeatured:desc&sort[1]=id:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[7]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}${type ? `&filters[type][$contains]=${type.replace(/ /g, '_')}` : ''}${tag ? `&filters[tags][$contains]=${tag.replace(/ /g, '_')}` : ''}`,
+					`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/posts?populate[0]=featuredImg&fields[0]=slug&fields[1]=summary&fields[2]=title&fields[3]=type&fields[4]=tags&fields[5]=publishedAt&fields[6]=isFeatured&sort[0]=isFeatured:desc&sort[1]=id:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[7]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}${type ? `&filters[type][$contains]=${type.replace(/ /g, '_')}` : ''}${tag ? `&filters[tags][$contains]=${tag.replace(/ /g, '_')}` : ''}`,
 					{
 						headers: {
-							Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+							Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 						}
 					}
 				);

--- a/app/[lang]/_hooks/useFetchSupportArticles.ts
+++ b/app/[lang]/_hooks/useFetchSupportArticles.ts
@@ -77,10 +77,10 @@ export function useFetchSupportArticles({
 		async function fetchArticles(): Promise<void> {
 			try {
 				const res = await fetch(
-					`${process.env.STRAPI_URL}/api/support-articles?populate[0]=featuredImg&fields[0]=slug&fields[1]=summary&fields[2]=title&fields[3]=publishedAt&sort[0]=publishedAt:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[4]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}`,
+					`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/support-articles?populate[0]=featuredImg&fields[0]=slug&fields[1]=summary&fields[2]=title&fields[3]=publishedAt&sort[0]=publishedAt:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[4]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}`,
 					{
 						headers: {
-							Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+							Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 						}
 					}
 				);

--- a/app/[lang]/_utils/query.ts
+++ b/app/[lang]/_utils/query.ts
@@ -20,7 +20,7 @@ import type {
  */
 const apiHeaders = {
 	headers: {
-		Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`
+		Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`
 	}
 };
 
@@ -31,7 +31,7 @@ const apiHeaders = {
  */
 export async function getFaq(): Promise<TFaqData | null> {
 	const res = await fetch(
-		`${process.env.STRAPI_URL}/api/faq?populate[0]=faqSection&populate[1]=faqSection.faqSectionItem&pagination[pageSize]=10&pagination[page]=1&status=published&locale=en`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/faq?populate[0]=faqSection&populate[1]=faqSection.faqSectionItem&pagination[pageSize]=10&pagination[page]=1&status=published&locale=en`,
 		apiHeaders
 	);
 
@@ -50,7 +50,7 @@ export async function getFaq(): Promise<TFaqData | null> {
  */
 export async function getSupportedWallet(slug: string): Promise<TSupportedWalletData | null> {
 	const res = await fetch(
-		`${process.env.STRAPI_URL}/api/supported-wallets?filters[slug][$eq]=${slug}&populate=*`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-wallets?filters[slug][$eq]=${slug}&populate=*`,
 		apiHeaders
 	);
 
@@ -69,7 +69,7 @@ export async function getSupportedWallet(slug: string): Promise<TSupportedWallet
  */
 export async function getSupportedChain(slug: string): Promise<TSupportedChainData | null> {
 	const res = await fetch(
-		`${process.env.STRAPI_URL}/api/supported-chains?filters[slug][$eq]=${slug}&populate=*`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-chains?filters[slug][$eq]=${slug}&populate=*`,
 		apiHeaders
 	);
 
@@ -88,7 +88,7 @@ export async function getSupportedChain(slug: string): Promise<TSupportedChainDa
  */
 export async function getSupportedProtocol(slug: string): Promise<TSupportedProtocolData | null> {
 	const res = await fetch(
-		`${process.env.STRAPI_URL}/api/supported-protocols?filters[slug][$eq]=${slug}&populate=*`,
+		`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-protocols?filters[slug][$eq]=${slug}&populate=*`,
 		apiHeaders
 	);
 
@@ -105,7 +105,7 @@ export async function getSupportedProtocol(slug: string): Promise<TSupportedProt
  * @returns Promise with array of discover data or null if request fails
  */
 export async function getDiscovers(): Promise<TDiscoverData[] | null> {
-	const res = await fetch(`${process.env.STRAPI_URL}/api/discovers?populate=*`, apiHeaders);
+	const res = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/discovers?populate=*`, apiHeaders);
 
 	if (!res.ok) {
 		return null;
@@ -120,7 +120,7 @@ export async function getDiscovers(): Promise<TDiscoverData[] | null> {
  * @returns Promise with privacy policy data or null if request fails
  */
 export async function getPrivacyPolicy(): Promise<TPrivacyPolicyData | null> {
-	const res = await fetch(`${process.env.STRAPI_URL}/api/privacy-policy?populate=*`, apiHeaders);
+	const res = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/privacy-policy?populate=*`, apiHeaders);
 
 	if (!res.ok) {
 		return null;
@@ -135,7 +135,7 @@ export async function getPrivacyPolicy(): Promise<TPrivacyPolicyData | null> {
  * @returns Promise with terms of service data or null if request fails
  */
 export async function getTermsOfService(): Promise<TTermsOfServiceData | null> {
-	const res = await fetch(`${process.env.STRAPI_URL}/api/terms-of-service?populate=*`, apiHeaders);
+	const res = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/terms-of-service?populate=*`, apiHeaders);
 
 	if (!res.ok) {
 		return null;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -64,7 +64,7 @@ export default async function RootLayout({children}: {children: ReactNode}): Pro
 						if (typeof Weglot !== 'undefined') {
 							try {
 								Weglot.initialize({
-									api_key: '${process.env.WEGLOT_API_KEY}',
+									api_key: '${process.env.NEXT_PUBLIC_WEGLOT_API_KEY}',
 									original_language: 'en',
 									languages: [${weglotLanguages
 										.split(',')

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,12 +3,6 @@ const nextConfig = {
 	crossOrigin: 'anonymous',
 	/* config options here */
 	reactStrictMode: true,
-	env: {
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		STRAPI_URL: process.env.STRAPI_URL ?? '',
-		// eslint-disable-next-line @typescript-eslint/naming-convention
-		STRAPI_API_TOKEN: process.env.STRAPI_API_TOKEN ?? ''
-	},
 	images: {
 		remotePatterns: [
 			{


### PR DESCRIPTION
We were already exposing these client side. NextJS convention is to use `NEXT_PUBLIC_` vernacular when naming to make this clear.

Also allows client side access to the chatwoot API key, which is not currently the case:

<img width="241" alt="Screenshot 2025-07-08 at 9 58 57 am" src="https://github.com/user-attachments/assets/39bf1e94-813c-4b60-8ccc-05787eb1c17e" />
