### PR TITLE
feat: redirect deprecated language subdomains

### DIFF
--- a/app/[lang]/_utils/i18nconfig.ts
+++ b/app/[lang]/_utils/i18nconfig.ts
@@ -51,6 +51,11 @@ export const SUPPORTED_LANGUAGES: TLanguage[] = [
 
 export const DEFAULT_LANGUAGE = 'en';
 
+/**
+ * Languages that were supported in the past but need special handling noe (e.g. subdomain redirections)
+ */
+export const DEPRECATED_LANGUAGES = ['br'];
+
 export function getLanguageFromPath(pathname: string): string {
 	const segments = pathname.split('/').filter(Boolean);
 	const firstSegment = segments[0];


### PR DESCRIPTION
Closes #34 

Redirects "br.shapeshift.com" (Portuguese) to English and preserve the existing paths.
Adds the ability to extend this handling to more languages if needed.