### PR TITLE
fix: coep headers

### DIFF
--- a/app/api/chatwoot/[...path]/route.ts
+++ b/app/api/chatwoot/[...path]/route.ts
@@ -1,113 +1,115 @@
-import { NextRequest, NextResponse } from 'next/server';
+import {NextResponse} from 'next/server';
+
+import type {NextRequest} from 'next/server';
 
 export async function GET(
-  request: NextRequest,
-  { params }: { params: { path: string[] } }
-) {
-  try {
-    const { path } = params;
-    const searchParams = request.nextUrl.searchParams;
+	request: NextRequest,
+	{params}: {params: {path: string[]}}
+): Promise<NextResponse> {
+  	try {
+		const {path} = params;
+		const searchParams = request.nextUrl.searchParams;
 
-    // Construct the Chatwoot URL
-    const chatwootPath = path.join('/');
-    const chatwootUrl = `https://app.chatwoot.com/${chatwootPath}?${searchParams.toString()}`;
+		// Construct the Chatwoot URL
+		const chatwootPath = path.join('/');
+		const chatwootUrl = `https://app.chatwoot.com/${chatwootPath}?${searchParams.toString()}`;
 
-    // Forward the request to Chatwoot
-    const response = await fetch(chatwootUrl, {
-      method: 'GET',
-      headers: {
-        'User-Agent': request.headers.get('user-agent') || 'ShapeShift-Proxy',
-        'Accept': request.headers.get('accept') || '*/*',
-        'Accept-Language': request.headers.get('accept-language') || 'en-US,en;q=0.9',
-        'Referer': request.headers.get('referer') || request.nextUrl.origin,
-      },
-    });
+		// Forward the request to Chatwoot
+		const response = await fetch(chatwootUrl, {
+			method: 'GET',
+			headers: {
+				'user-agent': request.headers.get('user-agent') || 'ShapeShift-Proxy',
+				accept: request.headers.get('accept') || '*/*',
+				'accept-language': request.headers.get('accept-language') || 'en-US,en;q=0.9',
+				referer: request.headers.get('referer') || request.nextUrl.origin
+			}
+		});
 
-    if (!response.ok) {
-      return new NextResponse(null, { status: response.status });
-    }
+    		if (!response.ok) {
+			return new NextResponse(null, {status: response.status});
+		}
 
-    const content = await response.text();
+		const content = await response.text();
 
-    // Create response with proper COEP headers
-    const nextResponse = new NextResponse(content, {
-      status: response.status,
-      headers: {
-        'Content-Type': response.headers.get('content-type') || 'text/html',
-        'Cross-Origin-Embedder-Policy': 'credentialless',
-        'Cross-Origin-Resource-Policy': 'cross-origin',
-        'Cross-Origin-Opener-Policy': 'same-origin',
-        'X-Frame-Options': 'SAMEORIGIN',
-        // Preserve some original headers
-        'Cache-Control': response.headers.get('cache-control') || 'no-cache',
-        'ETag': response.headers.get('etag') || '',
-        'Vary': response.headers.get('vary') || '',
-      }
-    });
+		// Create response with proper COEP headers
+		const nextResponse = new NextResponse(content, {
+			status: response.status,
+			headers: {
+				'content-type': response.headers.get('content-type') || 'text/html',
+				'cross-origin-embedder-policy': 'credentialless',
+				'cross-origin-resource-policy': 'cross-origin',
+				'cross-origin-opener-policy': 'same-origin',
+				'x-frame-options': 'SAMEORIGIN',
+				// Preserve some original headers
+				'cache-control': response.headers.get('cache-control') || 'no-cache',
+				etag: response.headers.get('etag') || '',
+				vary: response.headers.get('vary') || ''
+			}
+		});
 
-    // Copy Set-Cookie headers if present (for Chatwoot session)
-    const setCookieHeaders = response.headers.get('set-cookie');
-    if (setCookieHeaders) {
-      nextResponse.headers.set('Set-Cookie', setCookieHeaders);
-    }
+		// Copy Set-Cookie headers if present (for Chatwoot session)
+		const setCookieHeaders = response.headers.get('set-cookie');
+		if (setCookieHeaders) {
+			nextResponse.headers.set('Set-Cookie', setCookieHeaders);
+		}
 
-    return nextResponse;
-  } catch (error) {
-    console.error('Chatwoot proxy error:', error);
-    return new NextResponse('Proxy Error', { status: 500 });
-  }
+		return nextResponse;
+	} catch (error) {
+		console.error('Chatwoot proxy error:', error);
+		return new NextResponse('Proxy Error', {status: 500});
+	}
 }
 
 export async function POST(
-  request: NextRequest,
-  { params }: { params: { path: string[] } }
-) {
-  try {
-    const { path } = params;
-    const searchParams = request.nextUrl.searchParams;
-    const body = await request.text();
+	request: NextRequest,
+	{params}: {params: {path: string[]}}
+): Promise<NextResponse> {
+	try {
+		const {path} = params;
+		const searchParams = request.nextUrl.searchParams;
+		const body = await request.text();
 
-    // Construct the Chatwoot URL
-    const chatwootPath = path.join('/');
-    const chatwootUrl = `https://app.chatwoot.com/${chatwootPath}?${searchParams.toString()}`;
+		// Construct the Chatwoot URL
+		const chatwootPath = path.join('/');
+		const chatwootUrl = `https://app.chatwoot.com/${chatwootPath}?${searchParams.toString()}`;
 
-    // Forward the request to Chatwoot
-    const response = await fetch(chatwootUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': request.headers.get('content-type') || 'application/json',
-        'User-Agent': request.headers.get('user-agent') || 'ShapeShift-Proxy',
-        'Accept': request.headers.get('accept') || '*/*',
-        'Accept-Language': request.headers.get('accept-language') || 'en-US,en;q=0.9',
-        'Referer': request.headers.get('referer') || request.nextUrl.origin,
-      },
-      body: body || undefined,
-    });
+		// Forward the request to Chatwoot
+		const response = await fetch(chatwootUrl, {
+			method: 'POST',
+			headers: {
+				'content-type': request.headers.get('content-type') || 'application/json',
+				'user-agent': request.headers.get('user-agent') || 'ShapeShift-Proxy',
+				accept: request.headers.get('accept') || '*/*',
+				'accept-language': request.headers.get('accept-language') || 'en-US,en;q=0.9',
+				referer: request.headers.get('referer') || request.nextUrl.origin
+			},
+			body: body || undefined
+		});
 
-    const content = await response.text();
+    		const content = await response.text();
 
-    // Create response with proper COEP headers
-    const nextResponse = new NextResponse(content, {
-      status: response.status,
-      headers: {
-        'Content-Type': response.headers.get('content-type') || 'application/json',
-        'Cross-Origin-Embedder-Policy': 'credentialless',
-        'Cross-Origin-Resource-Policy': 'cross-origin',
-        'Cross-Origin-Opener-Policy': 'same-origin',
-        'X-Frame-Options': 'SAMEORIGIN',
-        'Cache-Control': response.headers.get('cache-control') || 'no-cache',
-      }
-    });
+		// Create response with proper COEP headers
+		const nextResponse = new NextResponse(content, {
+			status: response.status,
+			headers: {
+				'content-type': response.headers.get('content-type') || 'application/json',
+				'cross-origin-embedder-policy': 'credentialless',
+				'cross-origin-resource-policy': 'cross-origin',
+				'cross-origin-opener-policy': 'same-origin',
+				'x-frame-options': 'SAMEORIGIN',
+				'cache-control': response.headers.get('cache-control') || 'no-cache'
+			}
+		});
 
-    // Copy Set-Cookie headers if present
-    const setCookieHeaders = response.headers.get('set-cookie');
-    if (setCookieHeaders) {
-      nextResponse.headers.set('Set-Cookie', setCookieHeaders);
-    }
+		// Copy Set-Cookie headers if present
+		const setCookieHeaders = response.headers.get('set-cookie');
+		if (setCookieHeaders) {
+			nextResponse.headers.set('Set-Cookie', setCookieHeaders);
+		}
 
-    return nextResponse;
-  } catch (error) {
-    console.error('Chatwoot proxy error:', error);
-    return new NextResponse('Proxy Error', { status: 500 });
-  }
+		return nextResponse;
+	} catch (error) {
+		console.error('Chatwoot proxy error:', error);
+		return new NextResponse('Proxy Error', {status: 500});
+	}
 }

--- a/app/api/chatwoot/[...path]/route.ts
+++ b/app/api/chatwoot/[...path]/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { path: string[] } }
+) {
+  try {
+    const { path } = params;
+    const searchParams = request.nextUrl.searchParams;
+
+    // Construct the Chatwoot URL
+    const chatwootPath = path.join('/');
+    const chatwootUrl = `https://app.chatwoot.com/${chatwootPath}?${searchParams.toString()}`;
+
+    // Forward the request to Chatwoot
+    const response = await fetch(chatwootUrl, {
+      method: 'GET',
+      headers: {
+        'User-Agent': request.headers.get('user-agent') || 'ShapeShift-Proxy',
+        'Accept': request.headers.get('accept') || '*/*',
+        'Accept-Language': request.headers.get('accept-language') || 'en-US,en;q=0.9',
+        'Referer': request.headers.get('referer') || request.nextUrl.origin,
+      },
+    });
+
+    if (!response.ok) {
+      return new NextResponse(null, { status: response.status });
+    }
+
+    const content = await response.text();
+
+    // Create response with proper COEP headers
+    const nextResponse = new NextResponse(content, {
+      status: response.status,
+      headers: {
+        'Content-Type': response.headers.get('content-type') || 'text/html',
+        'Cross-Origin-Embedder-Policy': 'credentialless',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'X-Frame-Options': 'SAMEORIGIN',
+        // Preserve some original headers
+        'Cache-Control': response.headers.get('cache-control') || 'no-cache',
+        'ETag': response.headers.get('etag') || '',
+        'Vary': response.headers.get('vary') || '',
+      }
+    });
+
+    // Copy Set-Cookie headers if present (for Chatwoot session)
+    const setCookieHeaders = response.headers.get('set-cookie');
+    if (setCookieHeaders) {
+      nextResponse.headers.set('Set-Cookie', setCookieHeaders);
+    }
+
+    return nextResponse;
+  } catch (error) {
+    console.error('Chatwoot proxy error:', error);
+    return new NextResponse('Proxy Error', { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { path: string[] } }
+) {
+  try {
+    const { path } = params;
+    const searchParams = request.nextUrl.searchParams;
+    const body = await request.text();
+
+    // Construct the Chatwoot URL
+    const chatwootPath = path.join('/');
+    const chatwootUrl = `https://app.chatwoot.com/${chatwootPath}?${searchParams.toString()}`;
+
+    // Forward the request to Chatwoot
+    const response = await fetch(chatwootUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': request.headers.get('content-type') || 'application/json',
+        'User-Agent': request.headers.get('user-agent') || 'ShapeShift-Proxy',
+        'Accept': request.headers.get('accept') || '*/*',
+        'Accept-Language': request.headers.get('accept-language') || 'en-US,en;q=0.9',
+        'Referer': request.headers.get('referer') || request.nextUrl.origin,
+      },
+      body: body || undefined,
+    });
+
+    const content = await response.text();
+
+    // Create response with proper COEP headers
+    const nextResponse = new NextResponse(content, {
+      status: response.status,
+      headers: {
+        'Content-Type': response.headers.get('content-type') || 'application/json',
+        'Cross-Origin-Embedder-Policy': 'credentialless',
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'X-Frame-Options': 'SAMEORIGIN',
+        'Cache-Control': response.headers.get('cache-control') || 'no-cache',
+      }
+    });
+
+    // Copy Set-Cookie headers if present
+    const setCookieHeaders = response.headers.get('set-cookie');
+    if (setCookieHeaders) {
+      nextResponse.headers.set('Set-Cookie', setCookieHeaders);
+    }
+
+    return nextResponse;
+  } catch (error) {
+    console.error('Chatwoot proxy error:', error);
+    return new NextResponse('Proxy Error', { status: 500 });
+  }
+}

--- a/app/api/chatwoot/[...path]/route.ts
+++ b/app/api/chatwoot/[...path]/route.ts
@@ -1,3 +1,10 @@
+/*
+ * ESLint disable for naming-convention rule:
+ * HTTP headers must use kebab-case format (e.g., 'content-type', 'user-agent')
+ * but the project's naming convention rule requires camelCase/PascalCase.
+ * This is a legitimate case where the web standard takes precedence.
+ */
+/* eslint-disable @typescript-eslint/naming-convention */
 import {NextResponse} from 'next/server';
 
 import type {NextRequest} from 'next/server';
@@ -6,7 +13,7 @@ export async function GET(
 	request: NextRequest,
 	{params}: {params: {path: string[]}}
 ): Promise<NextResponse> {
-  	try {
+	try {
 		const {path} = params;
 		const searchParams = request.nextUrl.searchParams;
 
@@ -25,7 +32,7 @@ export async function GET(
 			}
 		});
 
-    		if (!response.ok) {
+		if (!response.ok) {
 			return new NextResponse(null, {status: response.status});
 		}
 
@@ -34,6 +41,7 @@ export async function GET(
 		// Create response with proper COEP headers
 		const nextResponse = new NextResponse(content, {
 			status: response.status,
+
 			headers: {
 				'content-type': response.headers.get('content-type') || 'text/html',
 				'cross-origin-embedder-policy': 'credentialless',
@@ -76,6 +84,7 @@ export async function POST(
 		// Forward the request to Chatwoot
 		const response = await fetch(chatwootUrl, {
 			method: 'POST',
+
 			headers: {
 				'content-type': request.headers.get('content-type') || 'application/json',
 				'user-agent': request.headers.get('user-agent') || 'ShapeShift-Proxy',
@@ -86,11 +95,12 @@ export async function POST(
 			body: body || undefined
 		});
 
-    		const content = await response.text();
+		const content = await response.text();
 
 		// Create response with proper COEP headers
 		const nextResponse = new NextResponse(content, {
 			status: response.status,
+
 			headers: {
 				'content-type': response.headers.get('content-type') || 'application/json',
 				'cross-origin-embedder-policy': 'credentialless',

--- a/middleware.ts
+++ b/middleware.ts
@@ -134,8 +134,13 @@ export function middleware(request: NextRequest): NextResponse {
 	// Set locale cookie
 	setLocaleCookie(response, locale);
 
+	// Set security headers including COEP
+	response.headers.set('Cross-Origin-Embedder-Policy', 'credentialless');
+	response.headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+	response.headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+
 	// Set the CSP header with the nonce
-	const cspHeader = `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://app.chatwoot.com https://widget.chatwoot.com https://cdn.weglot.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.weglot.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; media-src 'self' https:; connect-src 'self' https://app.chatwoot.com https://widget.chatwoot.com https://strapi.shapeshift.com https://cdn.weglot.com https://api.weglot.com https://cdn-api-weglot.com wss://app.chatwoot.com; frame-src 'self' https://widget.chatwoot.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://app.chatwoot.com; frame-ancestors 'self'; upgrade-insecure-requests;`;
+	const cspHeader = `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://app.chatwoot.com https://widget.chatwoot.com https://cdn.weglot.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.weglot.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; media-src 'self' https:; connect-src 'self' https://app.chatwoot.com https://widget.chatwoot.com https://strapi.shapeshift.com https://cdn.weglot.com https://api.weglot.com https://cdn-api-weglot.com wss://app.chatwoot.com; frame-src 'self' https://widget.chatwoot.com https://app.chatwoot.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://app.chatwoot.com; frame-ancestors 'self'; upgrade-insecure-requests;`;
 	response.headers.set('Content-Security-Policy', cspHeader);
 
 	// Handle locale routing
@@ -150,9 +155,9 @@ export const config = {
 		 * - _next/static (static files)
 		 * - _next/image (image optimization files)
 		 * - favicon.ico, sitemap.xml, robots.txt
-		 * - chatwoot (Chatwoot proxy path)
 		 * - public assets with extensions (images, fonts, etc.)
+		 * Note: Removed chatwoot exclusion to ensure COEP headers are applied
 		 */
-		'/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|chatwoot|.*\\.(?:svg|png|jpg|jpeg|gif|webp|webmanifest|ico|css|js|woff|woff2|ttf|otf)).*)'
+		'/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|.*\\.(?:svg|png|jpg|jpeg|gif|webp|webmanifest|ico|css|js|woff|woff2|ttf|otf)).*)'
 	]
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -155,9 +155,9 @@ export const config = {
 		 * - _next/static (static files)
 		 * - _next/image (image optimization files)
 		 * - favicon.ico, sitemap.xml, robots.txt
+		 * - chatwoot (now handled by API route)
 		 * - public assets with extensions (images, fonts, etc.)
-		 * Note: Removed chatwoot exclusion to ensure COEP headers are applied
 		 */
-		'/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|.*\\.(?:svg|png|jpg|jpeg|gif|webp|webmanifest|ico|css|js|woff|woff2|ttf|otf)).*)'
+		'/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|chatwoot|.*\\.(?:svg|png|jpg|jpeg|gif|webp|webmanifest|ico|css|js|woff|woff2|ttf|otf)).*)'
 	]
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,7 +22,8 @@ const nextConfig = {
 	async headers() {
 		return [
 			{
-				source: '/',
+				// Apply COEP headers to all routes
+				source: '/(.*)',
 				headers: [
 					{
 						key: 'cross-origin-embedder-policy',
@@ -35,6 +36,28 @@ const nextConfig = {
 					{
 						key: 'cross-origin-opener-policy',
 						value: 'same-origin'
+					}
+				]
+			},
+			{
+				// Specific headers for Chatwoot proxy to ensure iframe compatibility
+				source: '/chatwoot/(.*)',
+				headers: [
+					{
+						key: 'cross-origin-embedder-policy',
+						value: 'credentialless'
+					},
+					{
+						key: 'cross-origin-resource-policy',
+						value: 'cross-origin'
+					},
+					{
+						key: 'cross-origin-opener-policy',
+						value: 'same-origin'
+					},
+					{
+						key: 'x-frame-options',
+						value: 'SAMEORIGIN'
 					}
 				]
 			}

--- a/next.config.ts
+++ b/next.config.ts
@@ -67,7 +67,7 @@ const nextConfig = {
 		return [
 			{
 				source: '/chatwoot/:path*',
-				destination: 'https://app.chatwoot.com/:path*'
+				destination: '/api/chatwoot/:path*'
 			}
 		];
 	},


### PR DESCRIPTION
### Problem
The Chatwoot widget was failing to load due to Cross-Origin Embedder Policy (COEP) blocking errors. The main site had COEP enabled but the embedded Chatwoot iframe lacked the required matching headers, causing browsers to block the frame with the error:

> "Specify a Cross-Origin Embedder Policy to prevent this frame from being blocked"
### Root Cause
Next.js external rewrites (`/chatwoot/*` → `https://app.chatwoot.com/*`) don't preserve custom headers - they return the external server's response headers directly, bypassing our COEP configuration.

### Solution
**Created a custom API route proxy** to handle Chatwoot requests with proper COEP headers:

- **New API Route**: `app/api/chatwoot/[...path]/route.ts` 
  - Proxies GET/POST requests to `https://app.chatwoot.com`
  - Adds required COEP headers to all responses
  - Preserves Chatwoot session cookies and cache headers

- **Updated Rewrite**: Changed from external rewrite to internal API route
  ```diff
  - destination: 'https://app.chatwoot.com/:path*'
  + destination: '/api/chatwoot/:path*'
  ```

- **Enhanced Headers**: Applied consistent COEP headers across all routes
- **Middleware Cleanup**: Restored proper path exclusions for API routes

...and so, ChatWoot is great again:

<img width="278" height="132" alt="Screenshot 2025-08-04 at 10 14 18 am" src="https://github.com/user-attachments/assets/b96748b2-49d4-4ef1-94d7-34ef9662a3b5" />
