### PR TITLE
chore: restore sample env file

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_CHATWOOT_API_KEY=obtain-from-engineering
-NEXT_PUBLIC_ONRAMPER_URL=https://buy.onramper.com/?apiKey=<your-public-onramper-key>&defaultCrypto=btc&wallets=btc%3A&onlyCryptos=btc&supportSell=false&isAddressEditable=false&language=en&defaultFiat=USD&themeName=dark&redirectURL=https%3A%2F%2Fapp.shapeshift.com%2F%23%2Fbuy-crypto&signature=<server-generated-signature>
+NEXT_PUBLIC_ONRAMPER_URL=https://buy.onramper.com/?apiKey=pk_prod_01HWMA66BYRB2271G08XDZVVCX&defaultCrypto=btc&wallets=btc%3A&onlyCryptos=btc&supportSell=false&isAddressEditable=false&language=en&defaultFiat=USD&themeName=dark&redirectURL=https%3A%2F%2Fapp.shapeshift.com%2F%23%2Fbuy-crypto&signature=cf9f78149db21574bbfe02dc72a1ab15ae15a0bd25d7b932ef0b453d8a922f30
 NEXT_PUBLIC_STRAPI_API_TOKEN=obtain-from-engineering
 NEXT_PUBLIC_STRAPI_URL=https://strapi.shapeshift.com
 NEXT_PUBLIC_WEGLOT_API_KEY=obtain-from-engineering

--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_STRAPI_URL=https://strapi.shapeshift.com
+NEXT_PUBLIC_STRAPI_API_TOKEN=obtain-from-engineering
+NEXT_PUBLIC_WEGLOT_API_KEY=obtain-from-engineering
+NEXT_PUBLIC_ONRAMPER_URL=https://buy.onramper.com/?apiKey=pk_prod_01HWMA66BYRB2271G08XDZVVCX&defaultCrypto=btc&wallets=btc%3A&onlyCryptos=btc&supportSell=false&isAddressEditable=false&language=en&defaultFiat=USD&themeName=dark&redirectURL=https%3A%2F%2Fapp.shapeshift.com%2F%23%2Fbuy-crypto&signature=cf9f78149db21574bbfe02dc72a1ab15ae15a0bd25d7b932ef0b453d8a922f30
+NEXT_PUBLIC_CHATWOOT_API_KEY=obtain-from-engineering

--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,5 +1,5 @@
-NEXT_PUBLIC_STRAPI_URL=https://strapi.shapeshift.com
-NEXT_PUBLIC_STRAPI_API_TOKEN=obtain-from-engineering
-NEXT_PUBLIC_WEGLOT_API_KEY=obtain-from-engineering
-NEXT_PUBLIC_ONRAMPER_URL=https://buy.onramper.com/?apiKey=pk_prod_01HWMA66BYRB2271G08XDZVVCX&defaultCrypto=btc&wallets=btc%3A&onlyCryptos=btc&supportSell=false&isAddressEditable=false&language=en&defaultFiat=USD&themeName=dark&redirectURL=https%3A%2F%2Fapp.shapeshift.com%2F%23%2Fbuy-crypto&signature=cf9f78149db21574bbfe02dc72a1ab15ae15a0bd25d7b932ef0b453d8a922f30
 NEXT_PUBLIC_CHATWOOT_API_KEY=obtain-from-engineering
+NEXT_PUBLIC_ONRAMPER_URL=https://buy.onramper.com/?apiKey=<your-public-onramper-key>&defaultCrypto=btc&wallets=btc%3A&onlyCryptos=btc&supportSell=false&isAddressEditable=false&language=en&defaultFiat=USD&themeName=dark&redirectURL=https%3A%2F%2Fapp.shapeshift.com%2F%23%2Fbuy-crypto&signature=<server-generated-signature>
+NEXT_PUBLIC_STRAPI_API_TOKEN=obtain-from-engineering
+NEXT_PUBLIC_STRAPI_URL=https://strapi.shapeshift.com
+NEXT_PUBLIC_WEGLOT_API_KEY=obtain-from-engineering


### PR DESCRIPTION
Last merges removed the sample `.env` file mentioned in the README. This restores it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated sample environment file to include public variables for CMS, translations, buy-crypto widget, and in-app support.
  - Example buy-crypto URL in the sample was updated to include explicit query parameters for easier local testing.

- Chores
  - Added placeholders and guidance for obtaining required public keys to streamline local configuration.
  - No runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->