### PR TITLE
fix: chatwoot 404

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -68,6 +68,10 @@ const nextConfig = {
 			{
 				source: '/chatwoot/:path*',
 				destination: '/api/chatwoot/:path*'
+			},
+			{
+				source: '/api/v1/:path*',
+				destination: 'https://app.chatwoot.com/api/v1/:path*'
 			}
 		];
 	},


### PR DESCRIPTION
Currently there are a number of chatwoot requests that due to our configurations (baseUrl: '/api/chatwoot') get redirected to our backend chatwoot proxy. The URL's look like `/api/v1/` rather than `/api/chatwoot`. So the backend proxy doesn't properly register them. I.e. we have no routes set up to capture app.shapeshift/api/v1/... However you'd think then we could just fix it with

```
{
	source: '/api/v1/:path*',
	destination: '/api/chatwoot/:path*'
}
```

To direct it correctly to the internal proxy API. That does it fact redirect it however then we encounter different issues. We still get 404's even though the proxy is seemingly hitting the correct URL. There's most likely some shenanigans happening here with headers or cookies but I haven't got it to work via the proxy as of yet.

This change works on local but it's possible it will die in prod due to COEP headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a proxy route for Chatwoot API requests to improve reliability and reduce cross-origin issues while preserving existing Chatwoot behavior.
  * Integrated an early-loading third-party tag to enable third-party tracking/ads (loads non-blocking, respects CSP nonce).

* **Security**
  * Updated Content-Security-Policy to allow the new third-party script source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->