### PR TITLE
chore: align linting and formatting with main repo

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
 	"singleQuote": true,
-	"semi": true,
+	"semi": false,
 	"useTabs": true,
 	"tabWidth": 4,
 	"trailingComma": "none",

--- a/app/[lang]/(resources)/blog/(withNavigation)/tags/[tag]/ListOfPosts.tsx
+++ b/app/[lang]/(resources)/blog/(withNavigation)/tags/[tag]/ListOfPosts.tsx
@@ -21,7 +21,7 @@ export function ListOfPosts(props: {tag: string}): ReactElement {
 		page,
 		pageSize: PAGE_SIZE,
 		sort: SORT,
-		tag: tag,
+		tag,
 		populateContent: true,
 		cachePosts: true
 	});

--- a/app/[lang]/(resources)/newsroom/(withNavigation)/tags/[tag]/ListOfPosts.tsx
+++ b/app/[lang]/(resources)/newsroom/(withNavigation)/tags/[tag]/ListOfPosts.tsx
@@ -20,7 +20,7 @@ export function ListOfPosts(props: {tag: string}): ReactElement {
 		page,
 		pageSize: PAGE_SIZE,
 		sort: SORT,
-		tag: tag,
+		tag,
 		populateContent: true,
 		cachePosts: true
 	});

--- a/app/[lang]/_components/Notification.tsx
+++ b/app/[lang]/_components/Notification.tsx
@@ -118,14 +118,16 @@ export function Notification(): ReactNode {
 
 		switch (type) {
 			case 'bar':
-				setIsBannerOpen(false);
-				break;
+				setIsBannerOpen(false)
+				break
 			case 'modal':
-				setIsModalOpen(false);
-				break;
+				setIsModalOpen(false)
+				break
 			case 'popup':
-				setIsPopupOpen(false);
-				break;
+				setIsPopupOpen(false)
+				break
+			default:
+				break
 		}
 	};
 

--- a/app/[lang]/_utils/schema.ts
+++ b/app/[lang]/_utils/schema.ts
@@ -86,7 +86,7 @@ export function generateProductSchema({
 		id: productID,
 		name: title,
 		description: description || '',
-		image: image,
+		image,
 		url: pageURL,
 		applicationCategory: 'FinanceApplication',
 		operatingSystem: 'Web, Android, iOS',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,7 +103,6 @@ export default tseslint.config(
 			quotes: [2, 'single', { avoidEscape: true }],
 			'object-curly-spacing': [2, 'never'],
 			'array-bracket-spacing': [2, 'never'],
-			semi: 'error',
 			'no-else-return': ['error', { allowElseIf: false }],
 			'eol-last': ['error', 'always'],
 			'array-bracket-newline': ['error', { multiline: true }],
@@ -132,6 +131,10 @@ export default tseslint.config(
 				},
 			],
 
+			'object-shorthand': 'error',
+			'eqeqeq': 'error',
+			'default-case': 'error',
+
 			// TypeScript rules
 			'@typescript-eslint/consistent-type-imports': [
 				2,
@@ -150,17 +153,6 @@ export default tseslint.config(
 			'@typescript-eslint/consistent-type-assertions': 0,
 			'@typescript-eslint/consistent-type-definitions': ['error', 'type'],
 			'@typescript-eslint/consistent-indexed-object-style': ['error', 'record'],
-			'@typescript-eslint/explicit-function-return-type': [
-				'error',
-				{
-					allowExpressions: true,
-					allowTypedFunctionExpressions: true,
-					allowHigherOrderFunctions: false,
-					allowDirectConstAssertionInArrowFunctions: false,
-					allowConciseArrowFunctionExpressionsStartingWithVoid: false,
-					allowedNames: [],
-				},
-			],
 			'@typescript-eslint/naming-convention': [
 				'error',
 				{


### PR DESCRIPTION
Aligns the linting and formatting more closely with the main web repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized code style across the app (no semicolons) and enforced object shorthand, strict equality, and default-case in switch statements.
  - Minor refactors in post lists, newsroom tags, notifications, and schema to align with the new style. No user-facing behavior changes.
- Chores
  - Updated linting and formatting configurations to reflect the new standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->