### PR TITLE
fix: update thorchain api endpoint in swap widget

### DIFF
--- a/app/[lang]/_components/trading/TradingWidget.tsx
+++ b/app/[lang]/_components/trading/TradingWidget.tsx
@@ -45,7 +45,7 @@ export function TradingWidget(): ReactNode {
 			setIsLoading(true)
 			const numericAmount = Number(debouncedAmount)
 			fetch(
-				`https://daemon.thorchain.shapeshift.com/lcd/thorchain/quote/swap?amount=${numericAmount * 10 ** (fromToken.decimals[toToken.symbol?.toLowerCase() || 'eth'] || 6)}&from_asset=${fromChain.requestKey}.${fromToken.requestKey}&to_asset=${toChain.requestKey}.${toToken.requestKey}&affiliate_bps=64&affiliate=ss&streaming_interval=1`
+				`https://api.thorchain.shapeshift.com/lcd/thorchain/quote/swap?amount=${numericAmount * 10 ** (fromToken.decimals[toToken.symbol?.toLowerCase() || 'eth'] || 6)}&from_asset=${fromChain.requestKey}.${fromToken.requestKey}&to_asset=${toChain.requestKey}.${toToken.requestKey}&affiliate_bps=64&affiliate=ss&streaming_interval=1`
 			)
 				.then(async res => res.json())
 				.then(data => {


### PR DESCRIPTION
## Summary
- Fixed broken swap widget that was showing "No rate available" for THORChain routes
- Updated deprecated `daemon.thorchain.shapeshift.com` endpoint to `api.thorchain.shapeshift.com`
- Aligns with the same fix applied to the main web repo in commit 7de6e916af

Production (left) vs this branch (right):

<img width="2324" height="784" alt="Screenshot 2026-01-27 at 10 40 45 am" src="https://github.com/user-attachments/assets/c56821fc-6844-4d47-9b9b-f346b151f368" />

## Test plan
- [ ] Run the landing frontend locally
- [ ] Enter an amount in the swap widget (e.g., 1 BTC)
- [ ] Select a THORChain route (e.g., BTC → ETH)
- [ ] Verify a swap quote appears instead of "No rate available"
- [ ] Check browser DevTools Network tab confirms HTTP 200 from `api.thorchain.shapeshift.com`

Note, Solana does not currently work. I'll address that in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced stability of trading quote retrieval in the trading widget.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->