### PR TITLE
fix: enable Solana swaps via Chainflip with correct decimals

### DIFF
--- a/app/[lang]/_components/trading/TradingWidget.tsx
+++ b/app/[lang]/_components/trading/TradingWidget.tsx
@@ -17,6 +17,22 @@ import type {TChain} from './ChainSelect'
 import type {TToken} from './TokenSelect'
 import type {ReactNode} from 'react'
 
+const getChainflipAssetId = (token: TToken, chain: TChain): string => {
+	if (token.symbol === 'SOL') {
+		return 'Sol.Sol'
+	}
+	if (token.symbol === 'BTC') {
+		return 'Btc.Btc'
+	}
+	if (token.symbol === 'ETH') {
+		return 'Eth.Eth'
+	}
+	if (token.symbol === 'USDT') {
+		return 'Usdt.Eth'
+	}
+	return `${token.symbol}.${chain.requestKey}`
+}
+
 export function TradingWidget(): ReactNode {
 	const [fromToken, setFromToken] = useState<TToken>(SUPPORTED_TOKENS[0])
 	const [toToken, setToToken] = useState<TToken>(SUPPORTED_TOKENS[1])
@@ -76,8 +92,10 @@ export function TradingWidget(): ReactNode {
 		setIsLoading(true)
 		try {
 			const numericAmount = Number(debouncedAmount)
+			const sourceAsset = getChainflipAssetId(fromToken, fromChain)
+			const destinationAsset = getChainflipAssetId(toToken, toChain)
 			fetch(
-				`https://chainflip-broker.io/quotes-native?apiKey=09bc0796ff40435482c0a54fa6ae2784&sourceAsset=${fromToken.symbol}.${fromChain.requestKey}&destinationAsset=${toToken.symbol}.${toChain.requestKey}&amount=${numericAmount * 10 ** (fromToken.decimals[toToken.symbol?.toLowerCase() || 'eth'] || 6)}&commissionBps=63`
+				`https://chainflip-broker.io/quotes-native?apiKey=09bc0796ff40435482c0a54fa6ae2784&sourceAsset=${sourceAsset}&destinationAsset=${destinationAsset}&amount=${numericAmount * 10 ** (fromToken.decimals[toToken.symbol?.toLowerCase() || 'eth'] || 6)}&commissionBps=63`
 			)
 				.then(async res => res.json())
 				.then(data => {
@@ -98,11 +116,10 @@ export function TradingWidget(): ReactNode {
 		}
 	}, [
 		debouncedAmount,
-		fromToken.symbol,
-		fromToken.decimals,
-		fromChain.requestKey,
-		toToken.symbol,
-		toChain.requestKey
+		fromChain,
+		fromToken,
+		toChain,
+		toToken
 	])
 
 	useEffect(() => {
@@ -112,13 +129,6 @@ export function TradingWidget(): ReactNode {
 
 		if (toToken.symbol === fromToken.symbol && toChain.id === fromChain.id) {
 			return setError('Please select different tokens')
-		}
-		if (
-			(fromChain.id === 'solana' && toChain.id === 'bitcoin') ||
-			(fromToken.symbol === 'SOL' && toToken.symbol === 'ETH') ||
-			(fromToken.symbol === 'ETH' && toToken.symbol === 'SOL')
-		) {
-			return setError('No rate available')
 		}
 
 		if (fromChain.id === 'solana' || toChain.id === 'solana') {

--- a/app/[lang]/_components/trading/TradingWidget.tsx
+++ b/app/[lang]/_components/trading/TradingWidget.tsx
@@ -348,7 +348,9 @@ export function TradingWidget(): ReactNode {
 							{formatNumber(
 								outputAmount.amount,
 								outputAmount.isNative,
-								toToken.decimals[fromToken.symbol?.toLowerCase() || 'eth'] || 6
+								fromChain.id === 'solana' || toChain.id === 'solana'
+									? getChainflipDecimals(toToken)
+									: toToken.decimals[fromToken.symbol?.toLowerCase() || 'eth'] || 6
 							)}
 						</div>
 					)}

--- a/app/[lang]/_components/trading/TradingWidget.tsx
+++ b/app/[lang]/_components/trading/TradingWidget.tsx
@@ -33,6 +33,21 @@ const getChainflipAssetId = (token: TToken, chain: TChain): string => {
 	return `${token.symbol}.${chain.requestKey}`
 }
 
+const getChainflipDecimals = (token: TToken): number => {
+	switch (token.symbol) {
+		case 'SOL':
+			return 9
+		case 'BTC':
+			return 8
+		case 'ETH':
+			return 18
+		case 'USDT':
+			return 6
+		default:
+			return 18
+	}
+}
+
 export function TradingWidget(): ReactNode {
 	const [fromToken, setFromToken] = useState<TToken>(SUPPORTED_TOKENS[0])
 	const [toToken, setToToken] = useState<TToken>(SUPPORTED_TOKENS[1])
@@ -95,7 +110,7 @@ export function TradingWidget(): ReactNode {
 			const sourceAsset = getChainflipAssetId(fromToken, fromChain)
 			const destinationAsset = getChainflipAssetId(toToken, toChain)
 			fetch(
-				`https://chainflip-broker.io/quotes-native?apiKey=09bc0796ff40435482c0a54fa6ae2784&sourceAsset=${sourceAsset}&destinationAsset=${destinationAsset}&amount=${numericAmount * 10 ** (fromToken.decimals[toToken.symbol?.toLowerCase() || 'eth'] || 6)}&commissionBps=63`
+				`https://chainflip-broker.io/quotes-native?apiKey=09bc0796ff40435482c0a54fa6ae2784&sourceAsset=${sourceAsset}&destinationAsset=${destinationAsset}&amount=${numericAmount * 10 ** getChainflipDecimals(fromToken)}&commissionBps=63`
 			)
 				.then(async res => res.json())
 				.then(data => {

--- a/app/[lang]/_components/trading/TradingWidget.tsx
+++ b/app/[lang]/_components/trading/TradingWidget.tsx
@@ -109,8 +109,10 @@ export function TradingWidget(): ReactNode {
 			const numericAmount = Number(debouncedAmount)
 			const sourceAsset = getChainflipAssetId(fromToken, fromChain)
 			const destinationAsset = getChainflipAssetId(toToken, toChain)
+			const decimals = getChainflipDecimals(fromToken)
+			const amountInBaseUnits = BigInt(Math.round(numericAmount * 10 ** decimals)).toString()
 			fetch(
-				`https://chainflip-broker.io/quotes-native?apiKey=09bc0796ff40435482c0a54fa6ae2784&sourceAsset=${sourceAsset}&destinationAsset=${destinationAsset}&amount=${numericAmount * 10 ** getChainflipDecimals(fromToken)}&commissionBps=63`
+				`https://chainflip-broker.io/quotes-native?apiKey=09bc0796ff40435482c0a54fa6ae2784&sourceAsset=${sourceAsset}&destinationAsset=${destinationAsset}&amount=${amountInBaseUnits}&commissionBps=63`
 			)
 				.then(async res => res.json())
 				.then(data => {


### PR DESCRIPTION
## Summary
- Enable SOL ↔ ETH/BTC swaps that were previously blocked
- Fix amount calculation to use correct native decimals for each asset
- Fix output display to show human-readable amounts instead of scientific notation

## Root Cause
Multiple issues were preventing Solana swaps from working:

1. **Blocking logic**: An if-block was returning "No rate available" for SOL↔ETH and SOL→BTC pairs before even calling Chainflip
2. **Wrong decimals for API requests**: The amount calculation used `fromToken.decimals[toToken.symbol]` which looked up decimals based on the destination token instead of using the source token's native decimals
3. **Scientific notation in URL**: JavaScript's `10 ** 18` can produce `1e+18` when stringified, which Chainflip couldn't parse
4. **Wrong decimals for output display**: The output amount used THORChain decimals instead of Chainflip native decimals

## Changes

### 1. Remove blocking logic
Removed the if-block that blocked SOL↔ETH and SOL→BTC pairs - Chainflip now supports these.

### 2. Add `getChainflipAssetId` helper
Maps token/chain combinations to correct Chainflip asset identifiers:
- SOL → `Sol.Sol`
- BTC → `Btc.Btc`
- ETH → `Eth.Eth`
- USDT → `Usdt.Eth`

### 3. Add `getChainflipDecimals` helper
Returns correct native decimals for Chainflip assets:
- SOL: 9 decimals
- BTC: 8 decimals
- ETH: 18 decimals
- USDT: 6 decimals

### 4. Use BigInt for amount formatting
```typescript
const amountInBaseUnits = BigInt(Math.round(numericAmount * 10 ** decimals)).toString()
```
Ensures the amount is formatted as a proper integer string (e.g., `"1000000000"`) instead of scientific notation (`"1e+9"`).

### 5. Fix output display decimals
Use `getChainflipDecimals(toToken)` for Chainflip swaps to correctly format the received amount.

## Test Plan
- [x] SOL → ETH: Enter 1 SOL, verify quote returns ~0.04 ETH
- [x] ETH → SOL: Enter 1 ETH, verify quote returns ~23 SOL  
- [x] SOL → BTC: Enter 1 SOL, verify quote returns ~0.0014 BTC
- [x] ETH → BTC: Verify THORChain still works for non-Solana pairs
- [x] Output amounts display correctly (not in scientific notation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)