### PR TITLE
fix: update supported chains count from 15 to 48

### DIFF
--- a/app/[lang]/_utils/constants.tsx
+++ b/app/[lang]/_utils/constants.tsx
@@ -946,7 +946,7 @@ export const landingInfoCards = [
   },
   {
     title: 'Available chains',
-    stat: '15+',
+    stat: '48+',
   },
   {
     title: 'Assets',


### PR DESCRIPTION
The landing page currently displays "15+" supported chains, but ShapeShift now supports 48+ chains. This updates the `landingInfoCards` stat to reflect the correct number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "Available chains" metric displayed on the landing page from 15+ to 48+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->