### PR TITLE
feat: add developers navigation entrypoint

### DIFF
--- a/app/[lang]/_components/Footer.tsx
+++ b/app/[lang]/_components/Footer.tsx
@@ -29,8 +29,8 @@ export function Footer(): ReactNode {
         </div>
 
         {/* Middle row: Menu items */}
-        <div className={'mx-auto mt-12 w-full max-w-[720px]'}>
-          <div className={'grid grid-cols-2 gap-8 lg:grid-cols-4'}>
+        <div className={'mx-auto mt-12 w-full max-w-[960px]'}>
+          <div className={'grid grid-cols-2 gap-8 md:grid-cols-3 lg:grid-cols-5'}>
             {Object.entries(footerLinks).map(([category, links]) => (
               <div key={category} className={'flex flex-col gap-4'}>
                 <h3 className={'cursor-default text-sm font-medium text-gray-500'}>{category}</h3>

--- a/app/[lang]/_components/header/DesktopHeader.tsx
+++ b/app/[lang]/_components/header/DesktopHeader.tsx
@@ -15,6 +15,7 @@ import { dAppUrl, headerTabs } from '@/app/[lang]/_utils/constants'
 
 import { containerAnimation } from './animations'
 import { DAOExpand } from './DaoExpand'
+import { DevelopersExpand } from './DevelopersExpand'
 import { LanguageExpand } from './LanguageExpand'
 import { ProductsExpand } from './ProductsExpand'
 import { ResourcesExpand } from './ResourcesExpand'
@@ -41,6 +42,7 @@ export function DesktopHeader({ className, switchLanguageAction, currentLanguage
   const tabContent: Record<string, ReactNode> = useMemo(
     () => ({
       products: <ProductsExpand setCurrentTab={setCurrentTab} />,
+      developers: <DevelopersExpand setCurrentTab={setCurrentTab} />,
       resources: <ResourcesExpand setCurrentTab={setCurrentTab} />,
       dao: <DAOExpand setCurrentTab={setCurrentTab} />,
       language: <LanguageExpand switchLanguageAction={switchLanguageAction} currentLanguage={currentLanguage} />,

--- a/app/[lang]/_components/header/DevelopersExpand.tsx
+++ b/app/[lang]/_components/header/DevelopersExpand.tsx
@@ -1,0 +1,75 @@
+import { motion } from 'framer-motion'
+
+import { Button } from '@/app/[lang]/_components/Button'
+import { LocalizedLink } from '@/app/[lang]/_components/LocalizedLink'
+import { appDevelopers, developerDocsUrl } from '@/app/[lang]/_utils/constants'
+import { DEVELOPERS_DICT } from '@/app/[lang]/_utils/dictionary/developers'
+
+import { expandAnimation } from './animations'
+
+import type { TAppLink } from '@/app/[lang]/_utils/constants'
+import type { ReactNode } from 'react'
+
+function DeveloperItem({
+  name,
+  href,
+  target,
+  description,
+  icon,
+  onClick,
+}: TAppLink & { onClick: () => void }): ReactNode {
+  return (
+    <LocalizedLink
+      href={href}
+      target={target}
+      className={
+        'flex w-1/3 max-w-[232px] grow gap-2 rounded-lg px-6 py-4 transition-colors duration-300 hover:bg-white/10'
+      }
+      onClick={onClick}
+    >
+      <div className={'w-6 shrink-0'}>{icon}</div>
+      <div className={'ml-4 flex max-h-[120px] flex-col gap-1'}>
+        <span className={'whitespace-normal break-words text-sm font-medium leading-5'}>{name}</span>
+        {description && (
+          <span className={'whitespace-normal break-words text-xs leading-5 text-gray-500'}>{description}</span>
+        )}
+      </div>
+    </LocalizedLink>
+  )
+}
+
+export function DevelopersExpand({ setCurrentTab }: { setCurrentTab: (tab: string) => void }): ReactNode {
+  return (
+    <motion.div className={'grid grid-cols-12'} {...expandAnimation}>
+      <div className={'col-span-4 flex flex-col border-r border-white/5 p-16'}>
+        <p className={'mb-4 text-2xl font-medium'}>
+          {DEVELOPERS_DICT.expand.titleLine1} <br />
+          {DEVELOPERS_DICT.expand.titleLine2}
+        </p>
+        <p className={'mb-10 max-w-[327px] text-sm text-gray-500'}>{DEVELOPERS_DICT.expand.description}</p>
+        <Button
+          variant={'blue'}
+          className={'whitespace-nowrap'}
+          title={DEVELOPERS_DICT.expand.ctaButton}
+          href={developerDocsUrl}
+        />
+      </div>
+
+      <div className={'col-span-8 p-16'}>
+        <div className={'flex flex-row flex-wrap gap-4'}>
+          {appDevelopers.map((developerResource) => (
+            <DeveloperItem
+              onClick={() => setCurrentTab('empty')}
+              key={developerResource.name}
+              name={developerResource.name}
+              href={developerResource.href}
+              description={developerResource.description}
+              icon={developerResource.icon}
+              target={developerResource.target}
+            />
+          ))}
+        </div>
+      </div>
+    </motion.div>
+  )
+}

--- a/app/[lang]/_components/header/MobileHeader.tsx
+++ b/app/[lang]/_components/header/MobileHeader.tsx
@@ -11,7 +11,7 @@ import { IconClose } from '@/app/[lang]/_icons/IconClose'
 import { IconMenu } from '@/app/[lang]/_icons/IconMenu'
 import { IconPlanet } from '@/app/[lang]/_icons/IconPlanet'
 import { ShapeshiftLogo } from '@/app/[lang]/_icons/ShapeshiftLogo'
-import { appDao, appProducts, appResources, headerTabs } from '@/app/[lang]/_utils/constants'
+import { appDao, appDevelopers, appProducts, appResources, headerTabs } from '@/app/[lang]/_utils/constants'
 import { SUPPORTED_LANGUAGES } from '@/app/[lang]/_utils/i18nconfig'
 
 import type { TAppLink } from '@/app/[lang]/_utils/constants'
@@ -22,6 +22,11 @@ const mobileTabs: { name: string; value: string; items: TAppLink[] }[] = [
     name: 'Products',
     value: 'products',
     items: appProducts.slice(0, 6),
+  },
+  {
+    name: 'Developers',
+    value: 'developers',
+    items: appDevelopers.slice(0, 6),
   },
   {
     name: 'Resources',

--- a/app/[lang]/_utils/constants.tsx
+++ b/app/[lang]/_utils/constants.tsx
@@ -39,6 +39,10 @@ export const dAppUrl =
 
 const docsUrl = 'https://github.com/shapeshift/web'
 
+export const developerDocsUrl = 'https://api.shapeshift.com/docs'
+
+const developerDocsSectionUrl = (section: string): string => `${developerDocsUrl}${section}`
+
 const githubUrl = 'https://github.com/shapeshift'
 
 export const footerButtonTitle = 'Donate'
@@ -226,6 +230,51 @@ export const appResources: TAppLink[] = [
   },
 ]
 
+export const appDevelopers: TAppLink[] = [
+  {
+    name: 'Swap Widget SDK',
+    href: developerDocsSectionUrl('#tag/swap-widget-sdk'),
+    description: 'Integrate the drop-in swap widget with built-in UI.',
+    icon: <IconResource />,
+    target: '_blank',
+  },
+  {
+    name: 'REST API Guide',
+    href: developerDocsSectionUrl('#tag/rest-api-guide'),
+    description: 'Build a custom swap flow directly against the API.',
+    icon: <IconDocs />,
+    target: '_blank',
+  },
+  {
+    name: 'Swap API',
+    href: developerDocsSectionUrl('#tag/swaps'),
+    description: 'Get rates, executable quotes, and swap status.',
+    icon: <IconTriLink />,
+    target: '_blank',
+  },
+  {
+    name: 'Supported Assets',
+    href: developerDocsSectionUrl('#tag/supported-assets'),
+    description: 'List assets and fetch asset details by CAIP-19 ID.',
+    icon: <IconWallet />,
+    target: '_blank',
+  },
+  {
+    name: 'Supported Chains',
+    href: developerDocsSectionUrl('#tag/supported-chains'),
+    description: 'Review the chains available through the public API.',
+    icon: <IconChains />,
+    target: '_blank',
+  },
+  {
+    name: 'Affiliate Tracking',
+    href: developerDocsSectionUrl('#tag/affiliate'),
+    description: 'Register partner codes and review affiliate reporting.',
+    icon: <IconActivityRings />,
+    target: '_blank',
+  },
+]
+
 export const appDao: TAppLink[] = [
   {
     name: 'FOX Token',
@@ -314,12 +363,14 @@ export const appProducts: TAppLink[] = [
 
 export const headerTabs = [
   { name: 'Products', href: '/products', value: 'products' },
+  { name: 'Developers', href: developerDocsUrl, value: 'developers' },
   { name: 'Resources', href: '/resources', value: 'resources' },
   { name: 'DAO', href: '/dao', value: 'dao' },
 ]
 
 export const footerLinks: Record<string, TAppLink[]> = {
   Products: appProducts,
+  Developers: appDevelopers,
   Resources: appResources,
   DAO: appDao,
   Connect: [

--- a/app/[lang]/_utils/dictionary/developers.ts
+++ b/app/[lang]/_utils/dictionary/developers.ts
@@ -1,0 +1,8 @@
+export const DEVELOPERS_DICT = {
+  expand: {
+    titleLine1: 'Build with',
+    titleLine2: 'ShapeShift.',
+    description: 'Explore API documentation, integration guides, and reference material for crypto applications.',
+    ctaButton: 'View API Docs',
+  },
+} as const


### PR DESCRIPTION
﻿## Summary

Closes #98.

Adds a dedicated Developers entrypoint to the ShapeShift website navigation so the API documentation is easier to discover from shapeshift.com.

## Changes

- Adds a Developers dropdown to the desktop header
- Adds Developers links to the mobile navigation
- Adds a Developers section to the footer
- Links to key sections of the official ShapeShift API documentation
- Keeps the existing shared `HeaderItem` behavior unchanged by using a local Developers menu item layout for non-truncated documentation labels

## Testing

- `bunx eslint --no-cache "app/[lang]/_components/Footer.tsx" "app/[lang]/_components/header/DesktopHeader.tsx" "app/[lang]/_components/header/MobileHeader.tsx" "app/[lang]/_components/header/DevelopersExpand.tsx" "app/[lang]/_utils/constants.tsx" "app/[lang]/_utils/dictionary/developers.ts"`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- Local Playwright QA on `http://127.0.0.1:3001/fr`
  - desktop Developers dropdown renders all links
  - mobile Developers menu renders all links
  - no horizontal overflow detected
  - no ellipsis detected in Developers labels
  - each API docs link appears in header and footer
