### PR TITLE
fix: restore chatwoot bubble on localized pages

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -158,11 +158,6 @@ export function middleware(request: NextRequest): NextResponse {
     setLocaleCookie(response, locale)
   }
 
-  // Set security headers including COEP
-  response.headers.set('Cross-Origin-Embedder-Policy', 'credentialless')
-  response.headers.set('Cross-Origin-Resource-Policy', 'cross-origin')
-  response.headers.set('Cross-Origin-Opener-Policy', 'same-origin')
-
   // Set the CSP header with the nonce
   const cspHeader = `default-src 'self'; script-src 'self' 'nonce-${nonce}' https://api.hypelab.com https://app.chatwoot.com https://widget.chatwoot.com https://cdn.weglot.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.weglot.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; media-src 'self' https:; connect-src 'self' https://api.hypelab.com https://app.chatwoot.com https://widget.chatwoot.com ${strapiHostname} https://cdn.weglot.com https://api.weglot.com https://cdn-api-weglot.com wss://app.chatwoot.com  https://api.thorchain.shapeshift.com; frame-src 'self' https://widget.chatwoot.com https://app.chatwoot.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://app.chatwoot.com; frame-ancestors 'self'; upgrade-insecure-requests;`
   response.headers.set('Content-Security-Policy', cspHeader)


### PR DESCRIPTION
## Summary
- Fixes the support chat bubble disappearing on localized pages (e.g. `/fr/support`, `/en/support`) while still working on the un-prefixed path.

Resolves SS-5672.

## Test plan
- [ ] Hard-load `/fr/support` — chat bubble is visible
- [ ] Hard-load `/en/support` — chat bubble is visible
- [ ] Hard-load `/support` — chat bubble is visible
- [ ] Hard-load `/fr` (home) — chat bubble is visible
- [ ] Spot-check `/fr/trade` and `/fr/wallets` render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary cross-origin policy headers from server middleware configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/website-frontend/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->