### PR TITLE
refactor(strapi): read the Content API token server-side via a proxy

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_CHATWOOT_API_KEY=obtain-from-engineering
 NEXT_PUBLIC_ONRAMPER_URL=https://buy.onramper.com/?apiKey=pk_prod_01HWMA66BYRB2271G08XDZVVCX&defaultCrypto=btc&wallets=btc%3A&onlyCryptos=btc&supportSell=false&isAddressEditable=false&language=en&defaultFiat=USD&themeName=dark&redirectURL=https%3A%2F%2Fapp.shapeshift.com%2F%23%2Fbuy-crypto&signature=cf9f78149db21574bbfe02dc72a1ab15ae15a0bd25d7b932ef0b453d8a922f30
-NEXT_PUBLIC_STRAPI_API_TOKEN=obtain-from-engineering
+STRAPI_API_TOKEN=obtain-from-engineering
 NEXT_PUBLIC_STRAPI_URL=https://strapi.shapeshift.com
 NEXT_PUBLIC_WEGLOT_API_KEY=obtain-from-engineering

--- a/app/[lang]/(core-products)/_components/fetchUtils.ts
+++ b/app/[lang]/(core-products)/_components/fetchUtils.ts
@@ -14,7 +14,7 @@ export async function fetchWithErrorHandling<T>(
   try {
     const response = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/${endpoint}?${queryParams}`, {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
       next: {
         revalidate: 3600, // Cache for 1 hour

--- a/app/[lang]/(resources)/_utils/fetchUtils.ts
+++ b/app/[lang]/(resources)/_utils/fetchUtils.ts
@@ -26,7 +26,7 @@ import type {
 // Common headers and cache configuration
 const apiConfig = {
   headers: {
-    Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+    Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
   },
   next: {
     revalidate: 3600, // Cache for 1 hour

--- a/app/[lang]/(resources)/blog/(withNavigation)/categories/[category]/page.tsx
+++ b/app/[lang]/(resources)/blog/(withNavigation)/categories/[category]/page.tsx
@@ -11,7 +11,7 @@ export default async function BlogCategoriesPage(props: {
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/posts?filters[type][$contains]=${category}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc&pagination[pageSize]=1`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   )

--- a/app/[lang]/(resources)/blog/(withNavigation)/tags/[tag]/page.tsx
+++ b/app/[lang]/(resources)/blog/(withNavigation)/tags/[tag]/page.tsx
@@ -8,7 +8,7 @@ export default async function BlogTagsPage(props: { params: Promise<{ tag: strin
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/posts?filters[tags][$contains]=${tag}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   )

--- a/app/[lang]/(resources)/blog/[slug]/layout.tsx
+++ b/app/[lang]/(resources)/blog/[slug]/layout.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/posts?filters[slug][$eq]=${slug}&fields[0]=summary&fields[2]=tags&fields[3]=title&fields[4]=publishedAt&populate[0]=featuredImg`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   ).then(async (res) => res.json())

--- a/app/[lang]/(resources)/chains/[slug]/page.tsx
+++ b/app/[lang]/(resources)/chains/[slug]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-chains?filters[slug][$eq]=${slug}&populate=*`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   )

--- a/app/[lang]/(resources)/newsroom/(withNavigation)/categories/[category]/page.tsx
+++ b/app/[lang]/(resources)/newsroom/(withNavigation)/categories/[category]/page.tsx
@@ -10,7 +10,7 @@ export default async function BlogCategoriesPage(props: {
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/newsrooms?filters[category][$contains]=${category}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc&pagination[pageSize]=1`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   )

--- a/app/[lang]/(resources)/newsroom/(withNavigation)/tags/[tag]/page.tsx
+++ b/app/[lang]/(resources)/newsroom/(withNavigation)/tags/[tag]/page.tsx
@@ -8,7 +8,7 @@ export default async function NewsroomTagsPage(props: { params: Promise<{ tag: s
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/newsrooms?filters[tags][$contains]=${tag}&fields[0]=title&fields[1]=slug&fields[2]=publishedAt&populate[0]=featuredImg&sort[0]=publishedAt:desc`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   )

--- a/app/[lang]/(resources)/newsroom/[slug]/layout.tsx
+++ b/app/[lang]/(resources)/newsroom/[slug]/layout.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/newsrooms?filters[slug][$eq]=${slug}&fields[0]=postSummary&fields[1]=tags&fields[2]=title&fields[3]=publishedAt&populate[0]=featuredImg`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   ).then(async (res) => res.json())

--- a/app/[lang]/(resources)/protocols/[slug]/page.tsx
+++ b/app/[lang]/(resources)/protocols/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-protocols?filters[slug][$eq]=${slug}&populate=*`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   )

--- a/app/[lang]/(resources)/wallets/[slug]/page.tsx
+++ b/app/[lang]/(resources)/wallets/[slug]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/supported-wallets?filters[slug][$eq]=${slug}&populate=*`,
     {
       headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+        Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
       },
     }
   )

--- a/app/[lang]/_components/Notification.tsx
+++ b/app/[lang]/_components/Notification.tsx
@@ -52,10 +52,7 @@ export function Notification(): ReactNode {
     const fetchData = async (): Promise<void> => {
       try {
         setIsLoading(true)
-        const res = await fetch(`${process.env.NEXT_PUBLIC_STRAPI_URL}/api/notification?populate=*`, {
-          headers: {
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
-          },
+        const res = await fetch('/api/strapi/notification?populate=*', {
           signal: abortController.signal,
         })
 

--- a/app/[lang]/_hooks/useFetchNewsroom.tsx
+++ b/app/[lang]/_hooks/useFetchNewsroom.tsx
@@ -76,12 +76,7 @@ export function useFetchNewsroom({
       try {
         // Fetch posts with featured image population
         const res = await fetch(
-          `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/newsrooms?populate[0]=featuredImg&fields[0]=slug&fields[1]=postSummary&fields[2]=title&fields[3]=category&fields[4]=tags&fields[5]=publishedAt&fields[7]=publishedOn&fields[14]=author&fields[8]=externalURL&sort[0]=publishedOn:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[6]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}${category ? `&filters[category][$contains]=${category.replace(/ /g, '_')}` : ''}${tag ? `&filters[tags][$contains]=${tag.replace(/ /g, '_')}` : ''}`,
-          {
-            headers: {
-              Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
-            },
-          }
+          `/api/strapi/newsrooms?populate[0]=featuredImg&fields[0]=slug&fields[1]=postSummary&fields[2]=title&fields[3]=category&fields[4]=tags&fields[5]=publishedAt&fields[7]=publishedOn&fields[14]=author&fields[8]=externalURL&sort[0]=publishedOn:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[6]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}${category ? `&filters[category][$contains]=${category.replace(/ /g, '_')}` : ''}${tag ? `&filters[tags][$contains]=${tag.replace(/ /g, '_')}` : ''}`
         )
 
         if (!res.ok) {

--- a/app/[lang]/_hooks/useFetchPosts.tsx
+++ b/app/[lang]/_hooks/useFetchPosts.tsx
@@ -96,12 +96,7 @@ export function useFetchPosts({
       try {
         // Fetch posts with featured image population
         const res = await fetch(
-          `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/posts?populate[0]=featuredImg&fields[0]=slug&fields[1]=summary&fields[2]=title&fields[3]=type&fields[4]=tags&fields[5]=publishedAt&fields[6]=isFeatured&sort[0]=isFeatured:desc&sort[1]=id:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[7]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}${type ? `&filters[type][$contains]=${type.replace(/ /g, '_')}` : ''}${tag ? `&filters[tags][$contains]=${tag.replace(/ /g, '_')}` : ''}`,
-          {
-            headers: {
-              Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
-            },
-          }
+          `/api/strapi/posts?populate[0]=featuredImg&fields[0]=slug&fields[1]=summary&fields[2]=title&fields[3]=type&fields[4]=tags&fields[5]=publishedAt&fields[6]=isFeatured&sort[0]=isFeatured:desc&sort[1]=id:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[7]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}${type ? `&filters[type][$contains]=${type.replace(/ /g, '_')}` : ''}${tag ? `&filters[tags][$contains]=${tag.replace(/ /g, '_')}` : ''}`
         )
 
         if (!res.ok) {

--- a/app/[lang]/_hooks/useFetchSupportArticles.ts
+++ b/app/[lang]/_hooks/useFetchSupportArticles.ts
@@ -77,12 +77,7 @@ export function useFetchSupportArticles({
     async function fetchArticles(): Promise<void> {
       try {
         const res = await fetch(
-          `${process.env.NEXT_PUBLIC_STRAPI_URL}/api/support-articles?populate[0]=featuredImg&fields[0]=slug&fields[1]=summary&fields[2]=title&fields[3]=publishedAt&sort[0]=publishedAt:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[4]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}`,
-          {
-            headers: {
-              Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
-            },
-          }
+          `/api/strapi/support-articles?populate[0]=featuredImg&fields[0]=slug&fields[1]=summary&fields[2]=title&fields[3]=publishedAt&sort[0]=publishedAt:${sort}&pagination[page]=${page}&pagination[pageSize]=${pageSize}&pagination[withCount]=true${populateContent ? '&fields[4]=content' : ''}${slug ? `&filters[slug][$eq]=${slug}` : ''}`
         )
 
         if (!res.ok) {

--- a/app/[lang]/_utils/query.ts
+++ b/app/[lang]/_utils/query.ts
@@ -35,7 +35,7 @@ export function getStrapiImageUrl(url: string | null | undefined): string {
  */
 const apiHeaders = {
   headers: {
-    Authorization: `Bearer ${process.env.NEXT_PUBLIC_STRAPI_API_TOKEN}`,
+    Authorization: `Bearer ${process.env.STRAPI_API_TOKEN}`,
   },
 }
 

--- a/app/api/strapi/[...path]/route.ts
+++ b/app/api/strapi/[...path]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+
+import type { NextRequest } from 'next/server'
+
+/**
+ * Same-origin proxy for the Strapi Content API.
+ *
+ * Keeps the Strapi API token server-side: the browser calls /api/strapi/<path> with no
+ * credentials and this handler injects the bearer token before forwarding to Strapi. Only GET
+ * is proxied and the upstream path is always prefixed with /api/, so this cannot be used to reach
+ * Strapi admin or content-type-builder routes.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+): Promise<NextResponse> {
+  const strapiUrl = process.env.NEXT_PUBLIC_STRAPI_URL
+  const strapiToken = process.env.STRAPI_API_TOKEN
+
+  if (!strapiUrl || !strapiToken) {
+    return NextResponse.json({ error: 'Strapi proxy is not configured' }, { status: 500 })
+  }
+
+  const { path } = await params
+  const target = new URL(`/api/${path.join('/')}`, strapiUrl)
+  target.search = request.nextUrl.search
+
+  const upstream = await fetch(target, {
+    headers: { Authorization: `Bearer ${strapiToken}` },
+    next: { revalidate: 60 },
+  })
+
+  const body = await upstream.text()
+  return new NextResponse(body, {
+    status: upstream.status,
+    headers: { 'content-type': upstream.headers.get('content-type') ?? 'application/json' },
+  })
+}


### PR DESCRIPTION
## Description

The Strapi Content API token is currently read in client components, so it gets inlined into the browser bundle. Move it server-side. No change to what users see.

- New same-origin route `app/api/strapi/[...path]/route.ts` injects the token on the server and forwards GETs to Strapi. The upstream path is pinned to `/api/`.
- Client hooks/components (`useFetchPosts`, `useFetchNewsroom`, `useFetchSupportArticles`, `Notification`) call `/api/strapi/...` with no auth header.
- Server components/utils read the token from `STRAPI_API_TOKEN` (was `NEXT_PUBLIC_STRAPI_API_TOKEN`).

## Deploy note

Set `STRAPI_API_TOKEN` (no `NEXT_PUBLIC_` prefix) in the deploy env before this ships — without it the proxy returns 500 and server-rendered content fails.

## Manual QA

- Set `STRAPI_API_TOKEN` and `NEXT_PUBLIC_STRAPI_URL`, then `yarn dev`.
- Open the blog index, newsroom index, and support search; confirm lists load and pagination/filter/sort work (converted client hooks).
- Confirm the notification banner renders on the homepage.
- In DevTools Network, confirm client calls hit `/api/strapi/...` with no auth header.
- Load a blog post and a wallet/chain/protocol page (server-rendered) and confirm content renders.

## Verification

`tsc --noEmit` passes locally. Didn't run end-to-end here (no Strapi in this environment).
